### PR TITLE
Fix packaged desktop provider and storage defaults

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -77,7 +77,7 @@ async function createCliRuntime(eventSink: RuntimeEventSink): Promise<PaulusRunt
     const assertPlaintextMode = async (): Promise<void> => {
       const mode =
         (await storage.get<{ mode: PasswordStorageMode }>('credentials-meta'))?.mode ??
-        'plaintext-json'
+        'safe-storage'
 
       if (mode !== 'plaintext-json') {
         throw new Error(

--- a/apps/desktop/src/main/credential-store.ts
+++ b/apps/desktop/src/main/credential-store.ts
@@ -5,6 +5,7 @@ import type { StorageService } from '@paulus/core'
 
 const CREDENTIALS_KEY = 'credentials'
 const CREDENTIALS_META_KEY = 'credentials-meta'
+const DEFAULT_PASSWORD_STORAGE_MODE: PasswordStorageMode = 'safe-storage'
 
 interface StoredCredentials {
   [serverId: string]: string
@@ -134,7 +135,14 @@ export class DesktopCredentialStoreManager implements CredentialStore {
 
   async getMode(): Promise<PasswordStorageMode> {
     const metadata = await this.storage.get<CredentialMetadata>(CREDENTIALS_META_KEY)
-    return metadata?.mode ?? 'plaintext-json'
+    if (metadata?.mode) {
+      return metadata.mode
+    }
+
+    await this.storage.set<CredentialMetadata>(CREDENTIALS_META_KEY, {
+      mode: DEFAULT_PASSWORD_STORAGE_MODE,
+    })
+    return DEFAULT_PASSWORD_STORAGE_MODE
   }
 
   getModeOptions(): PasswordStorageModeOption[] {
@@ -151,7 +159,7 @@ export class DesktopCredentialStoreManager implements CredentialStore {
         mode: 'safe-storage',
         label: 'OS-backed encryption',
         description:
-          'Passwords are encrypted with Electron safeStorage and decrypted through your OS user account.',
+          'Passwords are encrypted with Electron safeStorage and decrypted through your OS user account. Default for desktop installs.',
         available: safeStorageAvailable,
         unavailableReason: safeStorageAvailable
           ? undefined

--- a/packages/ai/src/providers/acp-base.ts
+++ b/packages/ai/src/providers/acp-base.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { randomUUID } from 'crypto'
 import { tmpdir } from 'os'
 import type { AIEvent, AIModelOption } from '@paulus/shared'
@@ -34,7 +34,8 @@ export abstract class AcpBaseProvider implements AIProvider {
 
   async available(): Promise<boolean> {
     try {
-      execSync(`npx --yes ${this.packageName} --help`, {
+      const { command, args } = this.getLaunchCommand()
+      execFileSync(command, [...args, '--help'], {
         encoding: 'utf-8',
         timeout: 15000,
         stdio: 'pipe',
@@ -412,8 +413,16 @@ export abstract class AcpBaseProvider implements AIProvider {
   }
 
   private createClient(): AcpClient {
-    console.log(`[${this.name}] Spawning ACP agent: npx ${this.packageName}`)
-    return new AcpClient('npx', ['--yes', this.packageName], this.buildEnv())
+    const { command, args } = this.getLaunchCommand()
+    console.log(`[${this.name}] Spawning ACP agent: ${command} ${args.join(' ')}`)
+    return new AcpClient(command, args, this.buildEnv())
+  }
+
+  private getLaunchCommand(): { command: string; args: string[] } {
+    return {
+      command: 'npx',
+      args: ['--yes', this.packageName],
+    }
   }
 
   private buildEnv(): NodeJS.ProcessEnv {

--- a/packages/ui/src/components/settings/settings-view.tsx
+++ b/packages/ui/src/components/settings/settings-view.tsx
@@ -55,6 +55,10 @@ export function SettingsView({ onClose }: SettingsViewProps) {
   const [providerTestError, setProviderTestError] = useState<string | null>(null)
 
   useEffect(() => {
+    if (activeTab !== 'storage') {
+      return
+    }
+
     let cancelled = false
 
     const loadOverview = async () => {
@@ -76,7 +80,7 @@ export function SettingsView({ onClose }: SettingsViewProps) {
     return () => {
       cancelled = true
     }
-  }, [bridge])
+  }, [activeTab, bridge])
 
   if (!settings) return null
 


### PR DESCRIPTION
## Summary
- fix packaged desktop provider availability checks to use the same direct launch path as ACP session startup
- stop opening Settings from touching storage/keychain state until the Data Storage tab is selected
- make desktop password storage default to OS-backed encryption when no credentials metadata exists

## Verification
- bun run check

## Not backward compatible
- installs without existing credentials metadata now default to `safe-storage` instead of `plaintext-json`
- the CLI no longer assumes plaintext saved passwords when credentials metadata is missing