### PR TITLE
[codex] Improve packaged env and tool reliability

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -332,6 +332,50 @@ async function runChatSend(
           case 'text':
             process.stdout.write(event.text)
             break
+          case 'tool_state':
+            if (event.tool.kind !== 'server-command') {
+              break
+            }
+
+            if (event.tool.status === 'pending' && event.tool.command) {
+              process.stderr.write(`\n[command] ${event.tool.command}\n`)
+              void (async () => {
+                try {
+                  const approved = options.autoApprove
+                    ? true
+                    : await promptForApproval(event.tool.command!)
+                  if (!runtimeRef.current) return
+                  if (approved) {
+                    await runtimeRef.current.aiOrchestrator.approve(activeSessionId, event.tool.id)
+                  } else {
+                    await runtimeRef.current.aiOrchestrator.reject(activeSessionId, event.tool.id)
+                  }
+                } catch (err) {
+                  reject(err instanceof Error ? err : new Error(String(err)))
+                }
+              })()
+              break
+            }
+
+            if (event.tool.status === 'running' && event.tool.command) {
+              process.stderr.write(`[running] ${event.tool.command}\n`)
+              break
+            }
+
+            if (event.tool.status === 'completed' && event.tool.output) {
+              process.stderr.write(`[command exit ${event.tool.output.exitCode}]\n`)
+              break
+            }
+
+            if (event.tool.status === 'error' && event.tool.error) {
+              reject(new Error(event.tool.error))
+              break
+            }
+
+            if (event.tool.status === 'rejected') {
+              process.stderr.write('[command rejected]\n')
+            }
+            break
           case 'command_proposal':
             process.stderr.write(`\n[command] ${event.command}\n`)
             void (async () => {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -194,6 +194,7 @@ async function resolveSession(
   const session = await runtime.sessions.create(serverId, {
     provider: settings.activeProvider,
     model: null,
+    yoloMode: false,
   })
   return session.id
 }

--- a/apps/desktop/src/main/ai-orchestrator.ts
+++ b/apps/desktop/src/main/ai-orchestrator.ts
@@ -2,7 +2,13 @@ import { randomUUID } from 'crypto'
 import type { BrowserWindow } from 'electron'
 import type { AIEvent, AIMessage, AIModelOption, AIProviderType } from '@paulus/shared'
 import type { AIProcess } from '@paulus/ai'
-import { createProvider } from '@paulus/ai'
+import {
+  buildServerCommandToolState,
+  createCommandToolOutput,
+  createProvider,
+  formatCommandResultForModel,
+  toolStateEvent,
+} from '@paulus/ai'
 import type { ServerManager } from './ssh/server-manager'
 import type { SessionManager } from './session-manager'
 import type { SettingsManager } from './settings-manager'
@@ -12,6 +18,7 @@ interface PendingCommand {
   command: string
   serverId: string
   sessionId: string
+  startedAt: string
 }
 
 interface ActiveRun {
@@ -111,12 +118,18 @@ export class AIOrchestrator {
             this.emitAIEvent(sessionId, event)
           }
 
-          if (event.type === 'command_proposal') {
-            this.pendingCommands.set(event.id, {
-              id: event.id,
-              command: event.command,
+          if (
+            event.type === 'tool_state' &&
+            event.tool.kind === 'server-command' &&
+            event.tool.status === 'pending' &&
+            event.tool.command
+          ) {
+            this.pendingCommands.set(event.tool.id, {
+              id: event.tool.id,
+              command: event.tool.command,
               serverId,
               sessionId,
+              startedAt: event.tool.startedAt ?? new Date().toISOString(),
             })
           }
         }
@@ -127,6 +140,10 @@ export class AIOrchestrator {
           message: err.message,
         })
       } finally {
+        this.failPendingCommandsForSession(
+          sessionId,
+          'AI run ended before command execution completed',
+        )
         const run = this.activeRuns.get(sessionId)
         this.activeRuns.delete(sessionId)
 
@@ -152,55 +169,70 @@ export class AIOrchestrator {
     this.pendingCommands.delete(commandId)
 
     // Notify renderer that command is running
-    this.emitAIEvent(sessionId, {
-      type: 'command_running',
-      id: commandId,
-      command: pending.command,
-    })
+    this.emitAIEvent(
+      sessionId,
+      toolStateEvent(
+        buildServerCommandToolState({
+          id: commandId,
+          command: pending.command,
+          status: 'running',
+          startedAt: pending.startedAt,
+        }),
+      ),
+    )
 
     try {
       const result = await this.serverManager.pool.exec(pending.serverId, pending.command)
 
-      if (result.stdout) {
-        this.emitAIEvent(sessionId, {
-          type: 'command_output',
-          id: commandId,
-          data: result.stdout,
-          stream: 'stdout',
-        })
-      }
-
-      if (result.stderr) {
-        this.emitAIEvent(sessionId, {
-          type: 'command_output',
-          id: commandId,
-          data: result.stderr,
-          stream: 'stderr',
-        })
-      }
-
-      this.emitAIEvent(sessionId, {
-        type: 'command_done',
-        id: commandId,
-        exitCode: result.exitCode,
-      })
+      this.emitAIEvent(
+        sessionId,
+        toolStateEvent(
+          buildServerCommandToolState({
+            id: commandId,
+            command: pending.command,
+            status: 'completed',
+            startedAt: pending.startedAt,
+            endedAt: new Date().toISOString(),
+            output: createCommandToolOutput(result),
+          }),
+        ),
+      )
 
       // Feed output back to AI if process is still active
       const run = this.activeRuns.get(sessionId)
       if (run) {
-        run.process.write(
-          `Command completed (exit ${result.exitCode}):\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
-        )
+        run.process.write(formatCommandResultForModel(result))
       }
     } catch (err: any) {
-      this.emitAIEvent(sessionId, {
-        type: 'error',
-        message: `Command failed: ${err.message}`,
-      })
+      this.emitAIEvent(
+        sessionId,
+        toolStateEvent(
+          buildServerCommandToolState({
+            id: commandId,
+            command: pending.command,
+            status: 'error',
+            startedAt: pending.startedAt,
+            endedAt: new Date().toISOString(),
+            error: `Command failed: ${err.message}`,
+          }),
+        ),
+      )
+
+      const run = this.activeRuns.get(sessionId)
+      if (run) {
+        run.process.write(
+          formatCommandResultForModel({
+            exitCode: 1,
+            stdout: '',
+            stderr: `Command failed: ${err.message}`,
+          }),
+        )
+      }
     }
   }
 
   async reject(sessionId: string, commandId: string): Promise<void> {
+    const pending = this.pendingCommands.get(commandId)
     this.pendingCommands.delete(commandId)
 
     // Feed rejection back to AI process (needed for ACP providers to unblock pending tool calls)
@@ -209,18 +241,47 @@ export class AIOrchestrator {
       run.process.write('Command rejected by user')
     }
 
-    this.emitAIEvent(sessionId, {
-      type: 'command_done',
-      id: commandId,
-      exitCode: -1,
-    })
+    this.emitAIEvent(
+      sessionId,
+      toolStateEvent(
+        buildServerCommandToolState({
+          id: commandId,
+          command: pending?.command ?? '',
+          status: 'rejected',
+          startedAt: pending?.startedAt,
+          endedAt: new Date().toISOString(),
+          error: 'Command rejected by user',
+        }),
+      ),
+    )
   }
 
   kill(sessionId: string): void {
     const run = this.activeRuns.get(sessionId)
     if (run) {
+      this.failPendingCommandsForSession(sessionId, 'AI run was killed')
       run.process.kill()
       this.activeRuns.delete(sessionId)
+    }
+  }
+
+  private failPendingCommandsForSession(sessionId: string, reason: string): void {
+    for (const [commandId, pending] of this.pendingCommands) {
+      if (pending.sessionId !== sessionId) continue
+      this.pendingCommands.delete(commandId)
+      this.emitAIEvent(
+        sessionId,
+        toolStateEvent(
+          buildServerCommandToolState({
+            id: commandId,
+            command: pending.command,
+            status: 'error',
+            startedAt: pending.startedAt,
+            endedAt: new Date().toISOString(),
+            error: reason,
+          }),
+        ),
+      )
     }
   }
 

--- a/apps/desktop/src/main/ai-orchestrator.ts
+++ b/apps/desktop/src/main/ai-orchestrator.ts
@@ -56,6 +56,7 @@ export class AIOrchestrator {
     const session = await this.sessionManager.get(sessionId)
     const serverConfig = this.serverManager.getConfig(serverId)
     if (!serverConfig) throw new Error(`Server not found: ${serverId}`)
+    const yoloMode = session.yoloMode === true
 
     // Save user message
     const userMessage: AIMessage = {
@@ -131,6 +132,10 @@ export class AIOrchestrator {
               sessionId,
               startedAt: event.tool.startedAt ?? new Date().toISOString(),
             })
+
+            if (yoloMode) {
+              void this.approve(sessionId, event.tool.id)
+            }
           }
         }
       } catch (err: any) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, shell } from 'electron'
 import { join } from 'path'
 import { registerIPCHandlers } from './ipc'
 import { initLogger } from './logger'
-import { syncDesktopShellPath } from './shell-env'
+import { syncDesktopShellEnv } from './shell-env'
 
 const isDev = !app.isPackaged
 
@@ -49,7 +49,7 @@ async function createWindow(): Promise<BrowserWindow> {
 
 app.whenReady().then(async () => {
   if (app.isPackaged) {
-    syncDesktopShellPath()
+    syncDesktopShellEnv()
   }
 
   await createWindow()

--- a/apps/desktop/src/main/provider-self-test.ts
+++ b/apps/desktop/src/main/provider-self-test.ts
@@ -76,6 +76,11 @@ export async function testAIProvider(providerType: AIProviderType): Promise<AIPr
             continue
           }
 
+          if (event.type === 'tool_state' && event.tool.status === 'pending') {
+            toolCalls.push({ name: event.tool.toolName, argsText: event.tool.argsText })
+            continue
+          }
+
           if (event.type === 'error') {
             errors.push(event.message)
           }

--- a/apps/desktop/src/main/session-manager.ts
+++ b/apps/desktop/src/main/session-manager.ts
@@ -34,6 +34,7 @@ export class SessionManager {
       messages: [],
       provider: config.provider,
       model: config.model,
+      yoloMode: config.yoloMode,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     }
@@ -50,6 +51,7 @@ export class SessionManager {
     const session = await this.get(sessionId)
     session.provider = config.provider
     session.model = config.model
+    session.yoloMode = config.yoloMode
     session.updatedAt = new Date().toISOString()
     await this.save(session)
     return session
@@ -71,8 +73,13 @@ export class SessionManager {
       ? session.provider
       : DEFAULT_AI_PROVIDER
     const normalizedModel = typeof session.model === 'string' ? session.model : null
+    const normalizedYoloMode = session.yoloMode === true
 
-    if (normalizedProvider === session.provider && normalizedModel === session.model) {
+    if (
+      normalizedProvider === session.provider &&
+      normalizedModel === session.model &&
+      normalizedYoloMode === session.yoloMode
+    ) {
       return session
     }
 
@@ -80,6 +87,7 @@ export class SessionManager {
       ...session,
       provider: normalizedProvider,
       model: normalizedModel,
+      yoloMode: normalizedYoloMode,
     }
     await this.save(normalizedSession)
     return normalizedSession

--- a/apps/desktop/src/main/shell-env.test.js
+++ b/apps/desktop/src/main/shell-env.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildDesktopShellEnvArgs,
+  getDesktopUserShell,
+  mergeDesktopShellEnv,
+  parseDesktopShellEnv,
+} from './shell-env'
+
+describe('shell env bootstrap', () => {
+  test('reads the full environment from an interactive login shell', () => {
+    expect(buildDesktopShellEnvArgs()).toEqual(['-il', '-c', 'env -0'])
+  })
+
+  test('can read the full environment from a login shell fallback', () => {
+    expect(buildDesktopShellEnvArgs('-l')).toEqual(['-l', '-c', 'env -0'])
+  })
+
+  test('falls back to /bin/sh when SHELL is missing', () => {
+    const originalShell = process.env.SHELL
+    delete process.env.SHELL
+
+    try {
+      expect(getDesktopUserShell()).toBe('/bin/sh')
+    } finally {
+      if (originalShell === undefined) {
+        delete process.env.SHELL
+      } else {
+        process.env.SHELL = originalShell
+      }
+    }
+  })
+
+  test('parses null-delimited shell environment variables', () => {
+    const env = parseDesktopShellEnv(
+      Buffer.from('PATH=/opt/homebrew/bin:/usr/bin\0FOO=bar=baz\0\0'),
+    )
+
+    expect(env.PATH).toBe('/opt/homebrew/bin:/usr/bin')
+    expect(env.FOO).toBe('bar=baz')
+  })
+
+  test('ignores malformed shell environment entries', () => {
+    const env = parseDesktopShellEnv(Buffer.from('INVALID\0=empty\0OK=1\0'))
+
+    expect(env).toEqual({ OK: '1' })
+  })
+
+  test('keeps shell PATH while preserving explicit app environment values', () => {
+    const env = mergeDesktopShellEnv(
+      {
+        PATH: '/opt/homebrew/bin:/usr/bin',
+        HOME: '/Users/from-shell',
+      },
+      {
+        PATH: '/usr/bin:/bin',
+        PAULUS_DATA_PATH: '/tmp/paulus',
+      },
+    )
+
+    expect(env.PATH).toBe('/opt/homebrew/bin:/usr/bin')
+    expect(env.HOME).toBe('/Users/from-shell')
+    expect(env.PAULUS_DATA_PATH).toBe('/tmp/paulus')
+  })
+
+  test('uses app environment when shell probing fails', () => {
+    const env = mergeDesktopShellEnv(null, {
+      PATH: '/usr/bin:/bin',
+      PAULUS_DATA_PATH: '/tmp/paulus',
+    })
+
+    expect(env).toEqual({
+      PATH: '/usr/bin:/bin',
+      PAULUS_DATA_PATH: '/tmp/paulus',
+    })
+  })
+})

--- a/apps/desktop/src/main/shell-env.ts
+++ b/apps/desktop/src/main/shell-env.ts
@@ -1,38 +1,124 @@
-import { execFileSync } from 'child_process'
+import { spawnSync } from 'child_process'
 
-const PATH_MARKER_START = '__PAULUS_PATH_START__'
-const PATH_MARKER_END = '__PAULUS_PATH_END__'
+const SHELL_ENV_TIMEOUT_MS = 5000
+const SHELL_ENV_COMMAND = 'env -0'
 
-export function syncDesktopShellPath(): void {
+type ShellEnvProbe =
+  | { type: 'Loaded'; value: Record<string, string> }
+  | { type: 'Timeout' }
+  | { type: 'Unavailable' }
+
+type ShellEnvMode = '-il' | '-l'
+
+export function getDesktopUserShell(): string {
+  return process.env['SHELL'] || '/bin/sh'
+}
+
+export function buildDesktopShellEnvArgs(mode: ShellEnvMode = '-il'): string[] {
+  return [mode, '-c', SHELL_ENV_COMMAND]
+}
+
+export function parseDesktopShellEnv(output: Buffer): Record<string, string> {
+  const env: Record<string, string> = {}
+
+  for (const entry of output.toString('utf8').split('\0')) {
+    if (!entry) continue
+
+    const equalsIndex = entry.indexOf('=')
+    if (equalsIndex <= 0) continue
+
+    env[entry.slice(0, equalsIndex)] = entry.slice(equalsIndex + 1)
+  }
+
+  return env
+}
+
+export function mergeDesktopShellEnv(
+  shellEnv: Record<string, string> | null,
+  appEnv: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...(shellEnv ?? {}) }
+
+  for (const [key, value] of Object.entries(appEnv)) {
+    if (typeof value !== 'string') continue
+    if (shellEnv && (key === 'PATH' || key === 'Path')) continue
+    merged[key] = value
+  }
+
+  return merged
+}
+
+function probeDesktopShellEnv(shell: string, mode: ShellEnvMode): ShellEnvProbe {
+  const result = spawnSync(shell, buildDesktopShellEnvArgs(mode), {
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: SHELL_ENV_TIMEOUT_MS,
+    windowsHide: true,
+  })
+
+  const error = result.error as NodeJS.ErrnoException | undefined
+  if (error) {
+    if (error.code === 'ETIMEDOUT') return { type: 'Timeout' }
+    console.warn(`Failed to load shell environment from ${shell} ${mode}: ${error.message}`)
+    return { type: 'Unavailable' }
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.toString('utf8').trim()
+    console.warn(
+      stderr
+        ? `Failed to load shell environment from ${shell} ${mode}: ${stderr}`
+        : `Failed to load shell environment from ${shell} ${mode}: exit code ${result.status}`,
+    )
+    return { type: 'Unavailable' }
+  }
+
+  const shellEnv = parseDesktopShellEnv(result.stdout)
+  if (Object.keys(shellEnv).length === 0) {
+    console.warn(
+      `Failed to load shell environment from ${shell} ${mode}: shell returned no variables.`,
+    )
+    return { type: 'Unavailable' }
+  }
+
+  if (!shellEnv['PATH']) {
+    console.warn(`Failed to load shell environment from ${shell} ${mode}: shell returned no PATH.`)
+    return { type: 'Unavailable' }
+  }
+
+  return { type: 'Loaded', value: shellEnv }
+}
+
+export function loadDesktopShellEnv(shell: string): Record<string, string> | null {
+  const interactive = probeDesktopShellEnv(shell, '-il')
+  if (interactive.type === 'Loaded') {
+    return interactive.value
+  }
+
+  if (interactive.type === 'Timeout') {
+    console.warn(
+      `Interactive shell environment probe timed out for ${shell}. Using app environment.`,
+    )
+    return null
+  }
+
+  const login = probeDesktopShellEnv(shell, '-l')
+  if (login.type === 'Loaded') {
+    return login.value
+  }
+
+  console.warn(`Shell environment probe failed for ${shell}. Using app environment.`)
+  return null
+}
+
+export function syncDesktopShellEnv(): void {
   if (process.platform !== 'darwin') {
     return
   }
 
-  const shell = process.env['SHELL']
-  if (!shell) {
-    throw new Error('SHELL is not set. Cannot initialize PATH for the packaged desktop app.')
+  const shell = getDesktopUserShell()
+  const env = mergeDesktopShellEnv(loadDesktopShellEnv(shell), process.env)
+  for (const [key, value] of Object.entries(env)) {
+    process.env[key] = value
   }
-
-  const output = execFileSync(
-    shell,
-    ['-l', '-c', `printf '${PATH_MARKER_START}%s${PATH_MARKER_END}' "$PATH"`],
-    {
-      encoding: 'utf8',
-      env: process.env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  )
-
-  const start = output.indexOf(PATH_MARKER_START)
-  const end = output.indexOf(PATH_MARKER_END)
-  if (start === -1 || end === -1 || end <= start) {
-    throw new Error('Failed to read PATH from the login shell.')
-  }
-
-  const shellPath = output.slice(start + PATH_MARKER_START.length, end).trim()
-  if (!shellPath) {
-    throw new Error('The login shell returned an empty PATH.')
-  }
-
-  process.env.PATH = shellPath
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -37,10 +37,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   sessions: {
     list: (serverId: string) => ipcRenderer.invoke('sessions:list', serverId),
     get: (sessionId: string) => ipcRenderer.invoke('sessions:get', sessionId),
-    create: (serverId: string, config: { provider: string; model: string | null }) =>
-      ipcRenderer.invoke('sessions:create', { serverId, config }),
-    update: (sessionId: string, config: { provider: string; model: string | null }) =>
-      ipcRenderer.invoke('sessions:update', { sessionId, config }),
+    create: (
+      serverId: string,
+      config: { provider: string; model: string | null; yoloMode: boolean },
+    ) => ipcRenderer.invoke('sessions:create', { serverId, config }),
+    update: (
+      sessionId: string,
+      config: { provider: string; model: string | null; yoloMode: boolean },
+    ) => ipcRenderer.invoke('sessions:update', { sessionId, config }),
     delete: (sessionId: string) => ipcRenderer.invoke('sessions:delete', sessionId),
   },
   terminals: {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,2 +1,15 @@
 export type { AIProvider, AIProcess, AIContext, AIRunOptions } from './provider'
 export { createProvider } from './provider'
+export {
+  PAULUS_SERVER_COMMAND_TOOL,
+  TOOL_OUTPUT_PREVIEW_LIMIT,
+  buildGenericToolState,
+  buildInvalidToolState,
+  buildServerCommandToolState,
+  createCommandToolOutput,
+  createOutputPreview,
+  formatCommandResultForModel,
+  normalizePaulusToolName,
+  normalizeToolName,
+  toolStateEvent,
+} from './tool-state'

--- a/packages/ai/src/paulus-mcp-server.ts
+++ b/packages/ai/src/paulus-mcp-server.ts
@@ -18,10 +18,57 @@ interface McpToolServerOptions {
   onToolCall?: (toolName: string, args: Record<string, unknown>) => void
 }
 
+type McpToolContent = Array<{ type: 'text'; text: string }>
+type McpToolResult = { content: McpToolContent; isError?: boolean }
+
+function formatToolError(toolName: string, error: unknown): McpToolResult {
+  const message = error instanceof Error ? error.message : String(error)
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: `Tool ${toolName} failed: ${message}`,
+      },
+    ],
+  }
+}
+
+function defineMcpTool<TArgs extends Record<string, unknown>>(
+  toolName: string,
+  schema: z.ZodType<TArgs>,
+  options: McpToolServerOptions,
+  handler: (args: TArgs) => Promise<McpToolResult>,
+): (rawArgs: unknown) => Promise<McpToolResult> {
+  return async (rawArgs: unknown) => {
+    const parsed = schema.safeParse(rawArgs ?? {})
+    if (!parsed.success) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: `Invalid arguments for ${toolName}: ${parsed.error.message}`,
+          },
+        ],
+      }
+    }
+
+    options.onToolCall?.(toolName, parsed.data)
+
+    try {
+      return await handler(parsed.data)
+    } catch (error) {
+      return formatToolError(toolName, error)
+    }
+  }
+}
+
 function registerTools(mcpServer: McpServer, options: McpToolServerOptions): void {
   const commandSchema: z.ZodType<{ command: string }> = z.object({
     command: z.string().min(1).describe('Shell command to run on the selected remote server'),
   })
+  const emptySchema: z.ZodType<Record<string, never>> = z.object({})
 
   mcpServer.registerTool(
     'paulus_exec_server_command',
@@ -30,13 +77,12 @@ function registerTools(mcpServer: McpServer, options: McpToolServerOptions): voi
         'Execute a shell command on the selected remote server through Paulus Orchestrator.',
       inputSchema: commandSchema,
     },
-    async ({ command }: { command: string }) => {
-      options.onToolCall?.('paulus_exec_server_command', { command })
+    defineMcpTool('paulus_exec_server_command', commandSchema, options, async ({ command }) => {
       const result = await options.executeCommand(command)
       return {
         content: [
           {
-            type: 'text' as const,
+            type: 'text',
             text:
               `Command: ${command}\n` +
               `Exit code: ${result.exitCode}\n` +
@@ -45,21 +91,21 @@ function registerTools(mcpServer: McpServer, options: McpToolServerOptions): voi
           },
         ],
       }
-    },
+    }),
   )
 
   mcpServer.registerTool(
     'paulus_get_server_context',
     {
       description: 'Return the selected server metadata Paulus already knows.',
+      inputSchema: emptySchema,
     },
-    async () => {
-      options.onToolCall?.('paulus_get_server_context', {})
+    defineMcpTool('paulus_get_server_context', emptySchema, options, async () => {
       const server = options.server
       return {
         content: [
           {
-            type: 'text' as const,
+            type: 'text',
             text:
               `Name: ${server.name}\n` +
               `Host/IP: ${server.host}\n` +
@@ -71,7 +117,7 @@ function registerTools(mcpServer: McpServer, options: McpToolServerOptions): voi
           },
         ],
       }
-    },
+    }),
   )
 }
 

--- a/packages/ai/src/providers/acp-base.ts
+++ b/packages/ai/src/providers/acp-base.ts
@@ -6,11 +6,28 @@ import type { AIProvider, AIProcess, AIContext, AIRunOptions } from '../provider
 import { AcpClient } from '../acp-client'
 import { buildSystemPrompt } from '../context'
 import { PaulusMcpServer } from '../paulus-mcp-server'
+import {
+  buildGenericToolState,
+  buildInvalidToolState,
+  buildServerCommandToolState,
+  normalizePaulusToolName,
+  toolStateEvent,
+} from '../tool-state'
 
 interface PendingToolCall {
   commandId: string
+  command: string
+  startedAt: string
   resolve: (result: { stdout: string; stderr: string; exitCode: number }) => void
   reject: (err: Error) => void
+}
+
+interface ObservedToolCall {
+  toolName: string
+  args: Record<string, unknown>
+  argsText: string
+  title?: string
+  startedAt: string
 }
 
 /**
@@ -78,6 +95,7 @@ export abstract class AcpBaseProvider implements AIProvider {
 
     // --- State ---
     const pendingToolCalls = new Map<string, PendingToolCall>()
+    const observedToolCalls = new Map<string, ObservedToolCall>()
     const eventQueue: AIEvent[] = []
     let eventResolve: (() => void) | null = null
     let finished = false
@@ -87,20 +105,28 @@ export abstract class AcpBaseProvider implements AIProvider {
       executeCommand: async (command) => {
         return new Promise((resolve, reject) => {
           const cmdId = randomUUID()
+          const startedAt = new Date().toISOString()
 
           pendingToolCalls.set(cmdId, {
             commandId: cmdId,
+            command,
+            startedAt,
             resolve,
             reject,
           })
 
-          pushEvent({
-            type: 'command_proposal',
-            id: cmdId,
-            command,
-            explanation:
-              'AI wants Paulus to run a command on the selected server via paulus_exec_server_command',
-          })
+          pushEvent(
+            toolStateEvent(
+              buildServerCommandToolState({
+                id: cmdId,
+                command,
+                status: 'pending',
+                startedAt,
+                explanation:
+                  'AI wants Paulus to run a command on the selected server via paulus_exec_server_command',
+              }),
+            ),
+          )
         })
       },
     })
@@ -113,8 +139,29 @@ export abstract class AcpBaseProvider implements AIProvider {
       }
     }
 
-    function finish(): void {
+    function failPendingToolCalls(reason: string): void {
+      const endedAt = new Date().toISOString()
+      for (const [cmdId, pending] of pendingToolCalls) {
+        pushEvent(
+          toolStateEvent(
+            buildServerCommandToolState({
+              id: cmdId,
+              command: pending.command,
+              status: 'error',
+              startedAt: pending.startedAt,
+              endedAt,
+              error: reason,
+            }),
+          ),
+        )
+        pending.reject(new Error(reason))
+      }
+      pendingToolCalls.clear()
+    }
+
+    function finish(reason = 'Tool execution aborted'): void {
       if (!finished) {
+        failPendingToolCalls(reason)
         finished = true
         pushEvent({ type: 'done' })
       }
@@ -137,26 +184,52 @@ export abstract class AcpBaseProvider implements AIProvider {
         case 'tool_call': {
           const toolCall = this.extractToolCall(update)
           if (toolCall && !this.isCommandTool(toolCall.toolName)) {
-            pushEvent({
-              type: 'tool_call',
-              id: toolCall.id,
-              toolName: toolCall.toolName,
-              args: toolCall.args,
-              argsText: toolCall.argsText,
-              title: toolCall.title,
+            const startedAt = new Date().toISOString()
+            observedToolCalls.set(toolCall.id, {
+              ...toolCall,
+              startedAt,
             })
+            pushEvent(
+              toolStateEvent(
+                buildGenericToolState({
+                  id: toolCall.id,
+                  toolName: toolCall.toolName,
+                  args: toolCall.args,
+                  argsText: toolCall.argsText,
+                  title: toolCall.title,
+                  status: 'pending',
+                  startedAt,
+                }),
+              ),
+            )
           }
           break
         }
         case 'tool_result': {
           const toolResult = this.extractToolResult(update)
           if (toolResult) {
-            pushEvent({
-              type: 'tool_result',
-              id: toolResult.id,
-              result: toolResult.result,
-              isError: toolResult.isError,
-            })
+            const observed = observedToolCalls.get(toolResult.id)
+            observedToolCalls.delete(toolResult.id)
+            const endedAt = new Date().toISOString()
+            pushEvent(
+              toolStateEvent(
+                buildGenericToolState({
+                  id: toolResult.id,
+                  toolName: observed?.toolName ?? 'tool',
+                  args: observed?.args ?? {},
+                  argsText: observed?.argsText ?? '{}',
+                  title: observed?.title,
+                  status: toolResult.isError ? 'error' : 'completed',
+                  result: toolResult.result,
+                  isError: toolResult.isError,
+                  error: toolResult.isError
+                    ? this.stringifyToolResult(toolResult.result)
+                    : undefined,
+                  startedAt: observed?.startedAt,
+                  endedAt,
+                }),
+              ),
+            )
           } else if (update.content?.type === 'text' && update.content?.text) {
             pushEvent({ type: 'text', text: update.content.text })
           }
@@ -186,10 +259,22 @@ export abstract class AcpBaseProvider implements AIProvider {
       'exec',
     ]) {
       client.onRequest(method, (params) => {
-        const toolName = this.getToolName(method, params)
+        const toolName = normalizePaulusToolName(this.getToolName(method, params))
 
         // Reject all non-Paulus tools — they would run locally, not on the remote server
         if (!this.isPaulusTool(toolName) && !this.isCommandTool(toolName)) {
+          pushEvent(
+            toolStateEvent(
+              buildInvalidToolState({
+                id: randomUUID(),
+                toolName,
+                args: this.extractToolArgs(params),
+                error: `Tool "${toolName}" is not available. Use the paulus_exec_server_command MCP tool to run commands on the remote server.`,
+                metadata: { method },
+              }),
+            ),
+          )
+
           return Promise.resolve({
             error: `Tool "${toolName}" is not available. You MUST use the paulus_exec_server_command MCP tool to run commands on the remote server. Do not attempt to use built-in Bash, terminal, or shell tools.`,
           })
@@ -198,9 +283,12 @@ export abstract class AcpBaseProvider implements AIProvider {
         return new Promise((resolve, reject) => {
           const command = this.extractCommand(params)
           const cmdId = randomUUID()
+          const startedAt = new Date().toISOString()
 
           pendingToolCalls.set(cmdId, {
             commandId: cmdId,
+            command,
+            startedAt,
             resolve: (result) => {
               resolve({
                 stdout: result.stdout,
@@ -217,12 +305,17 @@ export abstract class AcpBaseProvider implements AIProvider {
             },
           })
 
-          pushEvent({
-            type: 'command_proposal',
-            id: cmdId,
-            command,
-            explanation: this.buildCommandExplanation(toolName),
-          })
+          pushEvent(
+            toolStateEvent(
+              buildServerCommandToolState({
+                id: cmdId,
+                command,
+                status: 'pending',
+                startedAt,
+                explanation: this.buildCommandExplanation(toolName),
+              }),
+            ),
+          )
         })
       })
     }
@@ -276,7 +369,7 @@ export abstract class AcpBaseProvider implements AIProvider {
 
     // Clean up on process exit
     client.onClose(() => {
-      finish()
+      finish('ACP process exited before tool execution completed')
     })
 
     // --- Start the ACP session ---
@@ -345,7 +438,7 @@ export abstract class AcpBaseProvider implements AIProvider {
         pushEvent({ type: 'error', message: err.message })
       } finally {
         await paulusMcpServer.close().catch(() => {})
-        finish()
+        finish('ACP run finished before tool execution completed')
       }
     })()
 
@@ -402,10 +495,7 @@ export abstract class AcpBaseProvider implements AIProvider {
 
       kill() {
         // Reject all pending tool calls
-        for (const [, pending] of pendingToolCalls) {
-          pending.reject(new Error('Process killed'))
-        }
-        pendingToolCalls.clear()
+        failPendingToolCalls('Process killed')
         void paulusMcpServer.close()
         client.kill()
       },
@@ -568,8 +658,26 @@ export abstract class AcpBaseProvider implements AIProvider {
     return JSON.stringify(input)
   }
 
+  private extractToolArgs(params: any): Record<string, unknown> {
+    const input = params?.input || params?.arguments || params || {}
+    if (input && typeof input === 'object' && !Array.isArray(input)) {
+      return input as Record<string, unknown>
+    }
+
+    return { value: input }
+  }
+
   private buildCommandExplanation(toolName: string): string {
     return `AI wants Paulus to run a command on the selected server via ${toolName}`
+  }
+
+  private stringifyToolResult(result: unknown): string {
+    if (typeof result === 'string') return result
+    try {
+      return JSON.stringify(result, null, 2)
+    } catch {
+      return String(result)
+    }
   }
 
   private extractToolCall(update: any): {

--- a/packages/ai/src/tool-state.test.js
+++ b/packages/ai/src/tool-state.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildInvalidToolState,
+  buildServerCommandToolState,
+  createCommandToolOutput,
+  createOutputPreview,
+  formatCommandResultForModel,
+  normalizePaulusToolName,
+} from './tool-state'
+
+describe('tool-state helpers', () => {
+  test('truncates output previews with omitted character counts', () => {
+    expect(createOutputPreview('abcdef', 3)).toEqual({
+      text: 'abc',
+      truncated: true,
+      omittedCharacters: 3,
+    })
+  })
+
+  test('keeps short output previews intact', () => {
+    expect(createOutputPreview('abc', 3)).toEqual({
+      text: 'abc',
+      truncated: false,
+      omittedCharacters: 0,
+    })
+  })
+
+  test('formats truncated command results for model-visible tool output', () => {
+    const output = formatCommandResultForModel(
+      {
+        exitCode: 1,
+        stdout: 'abcdef',
+        stderr: 'uvwxyz',
+      },
+      3,
+    )
+
+    expect(output).toContain('Command completed (exit 1)')
+    expect(output).toContain('abc')
+    expect(output).toContain('[stdout truncated; omitted 3 characters]')
+    expect(output).toContain('uvw')
+    expect(output).toContain('[stderr truncated; omitted 3 characters]')
+    expect(output).not.toContain('def')
+    expect(output).not.toContain('xyz')
+  })
+
+  test('builds server command tool states with command metadata', () => {
+    expect(
+      buildServerCommandToolState({
+        id: 'call-1',
+        command: 'uptime',
+        status: 'pending',
+        explanation: 'requires approval',
+      }),
+    ).toMatchObject({
+      id: 'call-1',
+      toolName: 'paulus_exec_server_command',
+      kind: 'server-command',
+      status: 'pending',
+      command: 'uptime',
+      args: { command: 'uptime' },
+      explanation: 'requires approval',
+    })
+  })
+
+  test('marks failed command output as an error state signal', () => {
+    const output = createCommandToolOutput({
+      exitCode: 2,
+      stdout: '',
+      stderr: 'failed',
+    })
+
+    expect(
+      buildServerCommandToolState({
+        id: 'call-1',
+        command: 'false',
+        status: 'completed',
+        output,
+      }),
+    ).toMatchObject({
+      isError: true,
+      output: {
+        exitCode: 2,
+      },
+    })
+  })
+
+  test('repairs Paulus tool names without changing unknown names', () => {
+    expect(normalizePaulusToolName('MCP__PAULUS__PAULUS_EXEC_SERVER_COMMAND')).toBe(
+      'paulus_exec_server_command',
+    )
+    expect(normalizePaulusToolName('CustomTool')).toBe('CustomTool')
+  })
+
+  test('creates model-visible invalid tool states', () => {
+    expect(
+      buildInvalidToolState({
+        id: 'invalid-1',
+        toolName: 'bash',
+        error: 'Use paulus_exec_server_command instead.',
+      }),
+    ).toMatchObject({
+      id: 'invalid-1',
+      kind: 'invalid',
+      status: 'error',
+      isError: true,
+      error: 'Use paulus_exec_server_command instead.',
+    })
+  })
+})

--- a/packages/ai/src/tool-state.ts
+++ b/packages/ai/src/tool-state.ts
@@ -1,0 +1,163 @@
+import type { AICommandToolOutput, AIEvent, AITextPreview, AIToolState } from '@paulus/shared'
+
+export const PAULUS_SERVER_COMMAND_TOOL = 'paulus_exec_server_command'
+export const TOOL_OUTPUT_PREVIEW_LIMIT = 20_000
+
+export interface CommandExecutionResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+export interface ToolStateInput {
+  id: string
+  toolName: string
+  args?: Record<string, unknown>
+  argsText?: string
+  title?: string
+  startedAt?: string
+  endedAt?: string
+  metadata?: Record<string, unknown>
+}
+
+export function normalizeToolName(toolName: string): string {
+  return toolName.trim().toLowerCase()
+}
+
+export function normalizePaulusToolName(toolName: string): string {
+  const normalized = normalizeToolName(toolName)
+  if (normalized.includes(PAULUS_SERVER_COMMAND_TOOL)) {
+    return PAULUS_SERVER_COMMAND_TOOL
+  }
+
+  if (normalized.includes('paulus_get_server_context')) {
+    return 'paulus_get_server_context'
+  }
+
+  return toolName
+}
+
+export function createOutputPreview(
+  value: string,
+  limit = TOOL_OUTPUT_PREVIEW_LIMIT,
+): AITextPreview {
+  if (value.length <= limit) {
+    return {
+      text: value,
+      truncated: false,
+      omittedCharacters: 0,
+    }
+  }
+
+  return {
+    text: value.slice(0, limit),
+    truncated: true,
+    omittedCharacters: value.length - limit,
+  }
+}
+
+export function createCommandToolOutput(
+  result: CommandExecutionResult,
+  limit = TOOL_OUTPUT_PREVIEW_LIMIT,
+): AICommandToolOutput {
+  return {
+    exitCode: result.exitCode,
+    stdout: createOutputPreview(result.stdout, limit),
+    stderr: createOutputPreview(result.stderr, limit),
+  }
+}
+
+export function formatCommandResultForModel(
+  result: CommandExecutionResult,
+  limit = TOOL_OUTPUT_PREVIEW_LIMIT,
+): string {
+  const output = createCommandToolOutput(result, limit)
+  const stdoutTruncation = output.stdout.truncated
+    ? `\n[stdout truncated; omitted ${output.stdout.omittedCharacters} characters]`
+    : ''
+  const stderrTruncation = output.stderr.truncated
+    ? `\n[stderr truncated; omitted ${output.stderr.omittedCharacters} characters]`
+    : ''
+
+  return (
+    `Command completed (exit ${output.exitCode}):\n` +
+    `STDOUT:\n${output.stdout.text}${stdoutTruncation}\n` +
+    `STDERR:\n${output.stderr.text}${stderrTruncation}`
+  )
+}
+
+export function buildServerCommandToolState(
+  input: Omit<ToolStateInput, 'toolName'> & {
+    command: string
+    status: AIToolState['status']
+    explanation?: string
+    output?: AICommandToolOutput
+    error?: string
+  },
+): AIToolState {
+  return {
+    id: input.id,
+    toolName: PAULUS_SERVER_COMMAND_TOOL,
+    kind: 'server-command',
+    status: input.status,
+    args: input.args ?? { command: input.command },
+    argsText: input.argsText ?? JSON.stringify({ command: input.command }, null, 2),
+    title: input.title ?? 'Run On Server',
+    command: input.command,
+    explanation: input.explanation,
+    output: input.output,
+    error: input.error,
+    isError: input.status === 'error' || Boolean(input.output && input.output.exitCode > 0),
+    startedAt: input.startedAt,
+    endedAt: input.endedAt,
+    metadata: input.metadata,
+  }
+}
+
+export function buildGenericToolState(
+  input: ToolStateInput & {
+    status: AIToolState['status']
+    result?: unknown
+    isError?: boolean
+    error?: string
+  },
+): AIToolState {
+  return {
+    id: input.id,
+    toolName: normalizePaulusToolName(input.toolName),
+    kind: 'tool',
+    status: input.status,
+    args: input.args ?? {},
+    argsText: input.argsText ?? JSON.stringify(input.args ?? {}, null, 2),
+    title: input.title,
+    result: input.result,
+    isError: input.isError ?? input.status === 'error',
+    error: input.error,
+    startedAt: input.startedAt,
+    endedAt: input.endedAt,
+    metadata: input.metadata,
+  }
+}
+
+export function buildInvalidToolState(input: ToolStateInput & { error: string }): AIToolState {
+  return {
+    id: input.id,
+    toolName: input.toolName || 'invalid',
+    kind: 'invalid',
+    status: 'error',
+    args: input.args ?? {},
+    argsText: input.argsText ?? JSON.stringify(input.args ?? {}, null, 2),
+    title: input.title ?? 'Invalid Tool Call',
+    error: input.error,
+    isError: true,
+    endedAt: input.endedAt ?? new Date().toISOString(),
+    metadata: input.metadata,
+  }
+}
+
+export function toolStateEvent(tool: AIToolState): AIEvent {
+  return {
+    type: 'tool_state',
+    tool,
+  }
+}

--- a/packages/core/src/ai-orchestrator.ts
+++ b/packages/core/src/ai-orchestrator.ts
@@ -49,6 +49,7 @@ export class AIOrchestrator {
     const session = await this.sessionManager.get(sessionId)
     const serverConfig = this.serverManager.getConfig(serverId)
     if (!serverConfig) throw new Error(`Server not found: ${serverId}`)
+    const yoloMode = session.yoloMode === true
 
     const userMessage: AIMessage = {
       id: randomUUID(),
@@ -107,6 +108,10 @@ export class AIOrchestrator {
               sessionId,
               startedAt: event.tool.startedAt ?? new Date().toISOString(),
             })
+
+            if (yoloMode) {
+              void this.approve(sessionId, event.tool.id)
+            }
           }
         }
       } finally {

--- a/packages/core/src/ai-orchestrator.ts
+++ b/packages/core/src/ai-orchestrator.ts
@@ -1,7 +1,13 @@
 import { randomUUID } from 'crypto'
 import type { AIEvent, AIMessage, AIModelOption, AIProviderType } from '@paulus/shared'
 import type { AIProcess } from '@paulus/ai'
-import { createProvider } from '@paulus/ai'
+import {
+  buildServerCommandToolState,
+  createCommandToolOutput,
+  createProvider,
+  formatCommandResultForModel,
+  toolStateEvent,
+} from '@paulus/ai'
 import type { RuntimeEventSink } from './events'
 import type { ServerManager } from './ssh/server-manager'
 import type { SessionManager } from './session-manager'
@@ -13,6 +19,7 @@ interface PendingCommand {
   command: string
   serverId: string
   sessionId: string
+  startedAt: string
 }
 
 interface ActiveRun {
@@ -87,16 +94,26 @@ export class AIOrchestrator {
         for await (const event of process.events) {
           this.emitAIEvent(sessionId, event)
 
-          if (event.type === 'command_proposal') {
-            this.pendingCommands.set(event.id, {
-              id: event.id,
-              command: event.command,
+          if (
+            event.type === 'tool_state' &&
+            event.tool.kind === 'server-command' &&
+            event.tool.status === 'pending' &&
+            event.tool.command
+          ) {
+            this.pendingCommands.set(event.tool.id, {
+              id: event.tool.id,
+              command: event.tool.command,
               serverId,
               sessionId,
+              startedAt: event.tool.startedAt ?? new Date().toISOString(),
             })
           }
         }
       } finally {
+        this.failPendingCommandsForSession(
+          sessionId,
+          'AI run ended before command execution completed',
+        )
         const run = this.activeRuns.get(sessionId)
         this.activeRuns.delete(sessionId)
 
@@ -125,11 +142,17 @@ export class AIOrchestrator {
     if (!pending) throw new Error(`No pending command: ${commandId}`)
 
     this.pendingCommands.delete(commandId)
-    this.emitAIEvent(sessionId, {
-      type: 'command_running',
-      id: commandId,
-      command: pending.command,
-    })
+    this.emitAIEvent(
+      sessionId,
+      toolStateEvent(
+        buildServerCommandToolState({
+          id: commandId,
+          command: pending.command,
+          status: 'running',
+          startedAt: pending.startedAt,
+        }),
+      ),
+    )
 
     try {
       await this.terminalSessions.recordCommand(sessionId, pending.command)
@@ -138,47 +161,56 @@ export class AIOrchestrator {
         sessionId,
         pending.command,
       )
-      if (result.stdout) {
-        this.emitAIEvent(sessionId, {
-          type: 'command_output',
-          id: commandId,
-          data: result.stdout,
-          stream: 'stdout',
-        })
-      }
-
-      if (result.stderr) {
-        this.emitAIEvent(sessionId, {
-          type: 'command_output',
-          id: commandId,
-          data: result.stderr,
-          stream: 'stderr',
-        })
-      }
-
-      this.emitAIEvent(sessionId, {
-        type: 'command_done',
-        id: commandId,
-        exitCode: result.exitCode,
-      })
+      this.emitAIEvent(
+        sessionId,
+        toolStateEvent(
+          buildServerCommandToolState({
+            id: commandId,
+            command: pending.command,
+            status: 'completed',
+            startedAt: pending.startedAt,
+            endedAt: new Date().toISOString(),
+            output: createCommandToolOutput(result),
+          }),
+        ),
+      )
 
       const run = this.activeRuns.get(sessionId)
       if (run) {
-        run.process.write(
-          `Command completed (exit ${result.exitCode}):\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
-        )
+        run.process.write(formatCommandResultForModel(result))
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       await this.terminalSessions.appendSystem(sessionId, `Error: ${message}`)
-      this.emitAIEvent(sessionId, {
-        type: 'error',
-        message: `Command failed: ${message}`,
-      })
+      this.emitAIEvent(
+        sessionId,
+        toolStateEvent(
+          buildServerCommandToolState({
+            id: commandId,
+            command: pending.command,
+            status: 'error',
+            startedAt: pending.startedAt,
+            endedAt: new Date().toISOString(),
+            error: `Command failed: ${message}`,
+          }),
+        ),
+      )
+
+      const run = this.activeRuns.get(sessionId)
+      if (run) {
+        run.process.write(
+          formatCommandResultForModel({
+            exitCode: 1,
+            stdout: '',
+            stderr: `Command failed: ${message}`,
+          }),
+        )
+      }
     }
   }
 
   async reject(sessionId: string, commandId: string): Promise<void> {
+    const pending = this.pendingCommands.get(commandId)
     this.pendingCommands.delete(commandId)
 
     const run = this.activeRuns.get(sessionId)
@@ -186,18 +218,47 @@ export class AIOrchestrator {
       run.process.write('Command rejected by user')
     }
 
-    this.emitAIEvent(sessionId, {
-      type: 'command_done',
-      id: commandId,
-      exitCode: -1,
-    })
+    this.emitAIEvent(
+      sessionId,
+      toolStateEvent(
+        buildServerCommandToolState({
+          id: commandId,
+          command: pending?.command ?? '',
+          status: 'rejected',
+          startedAt: pending?.startedAt,
+          endedAt: new Date().toISOString(),
+          error: 'Command rejected by user',
+        }),
+      ),
+    )
   }
 
   kill(sessionId: string): void {
     const run = this.activeRuns.get(sessionId)
     if (run) {
+      this.failPendingCommandsForSession(sessionId, 'AI run was killed')
       run.process.kill()
       this.activeRuns.delete(sessionId)
+    }
+  }
+
+  private failPendingCommandsForSession(sessionId: string, reason: string): void {
+    for (const [commandId, pending] of this.pendingCommands) {
+      if (pending.sessionId !== sessionId) continue
+      this.pendingCommands.delete(commandId)
+      this.emitAIEvent(
+        sessionId,
+        toolStateEvent(
+          buildServerCommandToolState({
+            id: commandId,
+            command: pending.command,
+            status: 'error',
+            startedAt: pending.startedAt,
+            endedAt: new Date().toISOString(),
+            error: reason,
+          }),
+        ),
+      )
     }
   }
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -41,6 +41,7 @@ export class SessionManager {
       messages: [],
       provider: config.provider,
       model: config.model,
+      yoloMode: config.yoloMode,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     }
@@ -61,6 +62,7 @@ export class SessionManager {
     const session = await this.get(sessionId)
     session.provider = config.provider
     session.model = config.model
+    session.yoloMode = config.yoloMode
     session.updatedAt = new Date().toISOString()
     await this.save(session)
     return session
@@ -128,8 +130,13 @@ export class SessionManager {
       ? session.provider
       : DEFAULT_AI_PROVIDER
     const normalizedModel = typeof session.model === 'string' ? session.model : null
+    const normalizedYoloMode = session.yoloMode === true
 
-    if (normalizedProvider === session.provider && normalizedModel === session.model) {
+    if (
+      normalizedProvider === session.provider &&
+      normalizedModel === session.model &&
+      normalizedYoloMode === session.yoloMode
+    ) {
       return session
     }
 
@@ -137,6 +144,7 @@ export class SessionManager {
       ...session,
       provider: normalizedProvider,
       model: normalizedModel,
+      yoloMode: normalizedYoloMode,
     }
     await this.save(normalizedSession)
     return normalizedSession

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -41,9 +41,44 @@ export interface TerminalSessionState {
   history: string[]
 }
 
+export type AIToolKind = 'server-command' | 'tool' | 'invalid'
+export type AIToolStatus = 'pending' | 'running' | 'completed' | 'error' | 'rejected'
+
+export interface AITextPreview {
+  text: string
+  truncated: boolean
+  omittedCharacters: number
+}
+
+export interface AICommandToolOutput {
+  exitCode: number
+  stdout: AITextPreview
+  stderr: AITextPreview
+}
+
+export interface AIToolState {
+  id: string
+  toolName: string
+  kind: AIToolKind
+  status: AIToolStatus
+  args: Record<string, unknown>
+  argsText: string
+  title?: string
+  command?: string
+  explanation?: string
+  result?: unknown
+  isError?: boolean
+  error?: string
+  output?: AICommandToolOutput
+  metadata?: Record<string, unknown>
+  startedAt?: string
+  endedAt?: string
+}
+
 export type AIEvent =
   | { type: 'text'; text: string }
   | { type: 'thinking'; text: string }
+  | { type: 'tool_state'; tool: AIToolState }
   | {
       type: 'tool_call'
       id: string

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -114,6 +114,7 @@ export interface AISession {
   messages: AIMessage[]
   provider: AIProviderType
   model: string | null
+  yoloMode: boolean
   createdAt: string
   updatedAt: string
 }
@@ -121,4 +122,5 @@ export interface AISession {
 export interface AISessionConfig {
   provider: AIProviderType
   model: string | null
+  yoloMode: boolean
 }

--- a/packages/ui/src/components/chat/chat-view.tsx
+++ b/packages/ui/src/components/chat/chat-view.tsx
@@ -7,7 +7,7 @@ import {
   type ReasoningMessagePartProps,
   type ToolCallMessagePartProps,
 } from '@assistant-ui/react'
-import type { AISessionConfig, AIProviderType } from '@paulus/shared'
+import type { AISessionConfig, AIProviderType, AIToolKind, AIToolStatus } from '@paulus/shared'
 import { useChatStore, useSettingsStore } from '../../stores'
 import { useBridge } from '../../hooks/use-bridge'
 import { useAssistantRuntime } from '../../hooks/use-assistant-runtime'
@@ -15,14 +15,19 @@ import { MarkdownText } from './markdown-text'
 import { AI_PROVIDER_LABELS, getSupportedAIProviders } from '../../lib/ai'
 
 type ToolArtifact = {
-  kind?: 'server-command' | 'tool'
-  status?: 'pending' | 'running' | 'complete' | 'rejected'
+  kind?: AIToolKind
+  status?: AIToolStatus
   title?: string
   command?: string
   explanation?: string
   stdout?: string
   stderr?: string
+  stdoutTruncated?: boolean
+  stderrTruncated?: boolean
   exitCode?: number
+  error?: string
+  startedAt?: string
+  endedAt?: string
 }
 
 interface ChatViewProps {
@@ -299,7 +304,7 @@ function ToolCallPart({
   const meta = (artifact ?? {}) as ToolArtifact
   const isServerCommand =
     meta.kind === 'server-command' || toolName === 'paulus_exec_server_command'
-  const status = meta.status ?? (result ? 'complete' : 'pending')
+  const status = meta.status ?? (result ? 'completed' : 'pending')
   const command = meta.command ?? (typeof args?.command === 'string' ? args.command : null)
   const title = meta.title ?? humanizeToolName(toolName)
   const exitCode =
@@ -332,10 +337,13 @@ function ToolCallPart({
     Boolean(command) ||
     Boolean(detailText) ||
     Boolean(meta.explanation) ||
+    Boolean(meta.error) ||
     showApprovalActions ||
     showExitCode ||
     Boolean(stdout) ||
     Boolean(stderr) ||
+    Boolean(meta.stdoutTruncated) ||
+    Boolean(meta.stderrTruncated) ||
     showGenericResult ||
     status === 'rejected'
 
@@ -379,6 +387,8 @@ function ToolCallPart({
               <p className="text-xs leading-5 text-zinc-400">{meta.explanation}</p>
             ) : null}
 
+            {meta.error ? <p className="text-xs leading-5 text-rose-300">{meta.error}</p> : null}
+
             {showApprovalActions ? (
               <div className="flex items-center gap-2">
                 <button
@@ -414,7 +424,15 @@ function ToolCallPart({
 
             {stdout ? <OutputBlock label="stdout" tone="text-emerald-200" value={stdout} /> : null}
 
+            {meta.stdoutTruncated ? (
+              <p className="text-[11px] text-zinc-500">stdout was truncated for display.</p>
+            ) : null}
+
             {stderr ? <OutputBlock label="stderr" tone="text-rose-200" value={stderr} /> : null}
+
+            {meta.stderrTruncated ? (
+              <p className="text-[11px] text-zinc-500">stderr was truncated for display.</p>
+            ) : null}
 
             {showGenericResult ? (
               <OutputBlock
@@ -474,8 +492,10 @@ function statusLabel(status: ToolArtifact['status']): string {
   switch (status) {
     case 'running':
       return 'Running'
-    case 'complete':
+    case 'completed':
       return 'Complete'
+    case 'error':
+      return 'Error'
     case 'rejected':
       return 'Rejected'
     case 'pending':
@@ -488,8 +508,10 @@ function statusTone(status: ToolArtifact['status']): string {
   switch (status) {
     case 'running':
       return 'bg-sky-950 text-sky-300 border border-sky-900/70'
-    case 'complete':
+    case 'completed':
       return 'bg-emerald-950 text-emerald-300 border border-emerald-900/70'
+    case 'error':
+      return 'bg-rose-950 text-rose-300 border border-rose-900/70'
     case 'rejected':
       return 'bg-zinc-800 text-zinc-300 border border-zinc-700'
     case 'pending':

--- a/packages/ui/src/components/chat/chat-view.tsx
+++ b/packages/ui/src/components/chat/chat-view.tsx
@@ -54,6 +54,7 @@ export function ChatView({ serverId, isConnected, connectionStatus }: ChatViewPr
     ? {
         provider: sessionForServer.provider,
         model: sessionForServer.model,
+        yoloMode: sessionForServer.yoloMode,
       }
     : (draftConfigs[serverId] ?? null)
 
@@ -78,6 +79,12 @@ export function ChatView({ serverId, isConnected, connectionStatus }: ChatViewPr
               : 'Viewing session history. Reconnect to continue chatting or approve commands.'}
           </div>
         )}
+
+        {selectedConfig?.yoloMode ? (
+          <div className="border-b border-red-900/70 bg-red-950/50 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-red-200">
+            Danger: YOLO mode is on. AI command tool calls auto-approve for this chat.
+          </div>
+        ) : null}
 
         <Thread serverId={serverId} isConnected={isConnected} />
       </div>
@@ -196,6 +203,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
     ? {
         provider: sessionForServer.provider,
         model: sessionForServer.model,
+        yoloMode: sessionForServer.yoloMode,
       }
     : (draftConfigs[serverId] ?? null)
 
@@ -228,6 +236,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
           const nextConfig = {
             provider,
             model: null,
+            yoloMode: config.yoloMode,
           } satisfies AISessionConfig
           applyConfig(nextConfig)
           loadModels(bridge, provider).catch(() => {})
@@ -250,6 +259,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
           applyConfig({
             provider: config.provider,
             model: event.target.value || null,
+            yoloMode: config.yoloMode,
           })
         }
         className="max-w-44 rounded-md border-none bg-zinc-700/40 px-2.5 py-1.5 text-[11px] text-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-500 disabled:opacity-50 cursor-pointer hover:bg-zinc-700/60 transition-colors appearance-none"
@@ -264,6 +274,26 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
           </option>
         ))}
       </select>
+
+      <button
+        type="button"
+        disabled={selectionDisabled}
+        onClick={() =>
+          applyConfig({
+            provider: config.provider,
+            model: config.model,
+            yoloMode: !config.yoloMode,
+          })
+        }
+        title="Danger: when enabled, AI command tool calls are auto-approved for this chat."
+        className={`rounded-md px-2.5 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em] transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+          config.yoloMode
+            ? 'border border-red-500/80 bg-red-600 text-white shadow-sm shadow-red-950/60 hover:bg-red-500'
+            : 'border border-zinc-700/70 bg-zinc-800/50 text-zinc-500 hover:bg-zinc-700/70 hover:text-zinc-300'
+        }`}
+      >
+        YOLO
+      </button>
 
       {modelError ? (
         <span className="text-[10px] text-amber-400/80 ml-1" title={modelError}>

--- a/packages/ui/src/components/chat/message-content.ts
+++ b/packages/ui/src/components/chat/message-content.ts
@@ -1,15 +1,26 @@
 import type { ThreadMessageLike } from '@assistant-ui/react'
-import type { AIEvent, AIMessage } from '@paulus/shared'
+import type {
+  AICommandToolOutput,
+  AIEvent,
+  AIMessage,
+  AIToolKind,
+  AIToolStatus,
+} from '@paulus/shared'
 
 type ToolArtifact = {
-  kind?: 'server-command' | 'tool'
-  status?: 'pending' | 'running' | 'complete' | 'rejected'
+  kind?: AIToolKind
+  status?: AIToolStatus
   title?: string
   command?: string
   explanation?: string
   stdout?: string
   stderr?: string
+  stdoutTruncated?: boolean
+  stderrTruncated?: boolean
   exitCode?: number
+  error?: string
+  startedAt?: string
+  endedAt?: string
 }
 
 type MessageContent = Exclude<ThreadMessageLike['content'], string>
@@ -67,6 +78,25 @@ function normalizeToolCallArgs(event: Extract<AIEvent, { type: 'tool_call' }>): 
   }
 }
 
+function getCommandOutput(output: unknown): AICommandToolOutput | null {
+  if (!output || typeof output !== 'object') return null
+
+  const candidate = output as Partial<AICommandToolOutput>
+  if (
+    typeof candidate.exitCode === 'number' &&
+    candidate.stdout &&
+    typeof candidate.stdout === 'object' &&
+    typeof candidate.stdout.text === 'string' &&
+    candidate.stderr &&
+    typeof candidate.stderr === 'object' &&
+    typeof candidate.stderr.text === 'string'
+  ) {
+    return candidate as AICommandToolOutput
+  }
+
+  return null
+}
+
 function upsertToolCall(
   parts: MutableMessageContent,
   toolIndex: Map<string, number>,
@@ -120,6 +150,49 @@ export function buildMessageContent(message: AIMessage): MessageContent | string
       case 'thinking':
         appendTextPart(parts, 'reasoning', event.text)
         break
+      case 'tool_state': {
+        const tool = event.tool
+        const commandOutput = getCommandOutput(tool.output)
+        const result =
+          tool.result ??
+          (commandOutput
+            ? {
+                exitCode: commandOutput.exitCode,
+                stdout: commandOutput.stdout.text,
+                stderr: commandOutput.stderr.text,
+                stdoutTruncated: commandOutput.stdout.truncated,
+                stderrTruncated: commandOutput.stderr.truncated,
+              }
+            : tool.error
+              ? { error: tool.error }
+              : undefined)
+
+        upsertToolCall(parts, toolIndex, tool.id, {
+          toolName: tool.toolName,
+          args: tool.args,
+          argsText: tool.argsText,
+          result,
+          isError:
+            tool.isError ??
+            (tool.status === 'error' || (commandOutput ? commandOutput.exitCode > 0 : false)),
+          artifact: {
+            kind: tool.kind,
+            status: tool.status,
+            title: tool.title,
+            command: tool.command,
+            explanation: tool.explanation,
+            stdout: commandOutput?.stdout.text,
+            stderr: commandOutput?.stderr.text,
+            stdoutTruncated: commandOutput?.stdout.truncated,
+            stderrTruncated: commandOutput?.stderr.truncated,
+            exitCode: commandOutput?.exitCode,
+            error: tool.error,
+            startedAt: tool.startedAt,
+            endedAt: tool.endedAt,
+          },
+        })
+        break
+      }
       case 'tool_call': {
         const { args, argsText } = normalizeToolCallArgs(event)
         upsertToolCall(parts, toolIndex, event.id, {
@@ -143,7 +216,7 @@ export function buildMessageContent(message: AIMessage): MessageContent | string
           isError: event.isError,
           artifact: {
             kind: 'tool',
-            status: 'complete',
+            status: event.isError ? 'error' : 'completed',
           },
         })
         break
@@ -200,7 +273,7 @@ export function buildMessageContent(message: AIMessage): MessageContent | string
           isError: event.exitCode > 0,
           artifact: {
             kind: 'server-command',
-            status: event.exitCode === -1 ? 'rejected' : 'complete',
+            status: event.exitCode === -1 ? 'rejected' : 'completed',
             exitCode: event.exitCode,
           },
         })

--- a/packages/ui/src/components/terminal/terminal-console.tsx
+++ b/packages/ui/src/components/terminal/terminal-console.tsx
@@ -78,12 +78,21 @@ export function TerminalConsole({ serverId, isConnected }: TerminalConsoleProps)
 
   useEffect(() => {
     const unsub = bridge.ai.onEvent((event) => {
-      if (event.sessionId !== sessionId || event.type !== 'command_running') return
+      if (
+        event.sessionId !== sessionId ||
+        event.type !== 'tool_state' ||
+        event.tool.kind !== 'server-command' ||
+        event.tool.status !== 'running' ||
+        !event.tool.command
+      ) {
+        return
+      }
+
       setLines((prev) => [
         ...prev,
         {
           id: ++lineId,
-          text: `$ ${event.command}`,
+          text: `$ ${event.tool.command}`,
           type: 'stdin',
         },
       ])

--- a/packages/ui/src/stores/chat-store.ts
+++ b/packages/ui/src/stores/chat-store.ts
@@ -273,6 +273,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         }))
         break
       case 'thinking':
+      case 'tool_state':
       case 'tool_call':
       case 'tool_result':
       case 'command_proposal':

--- a/packages/ui/src/stores/chat-store.ts
+++ b/packages/ui/src/stores/chat-store.ts
@@ -44,6 +44,7 @@ async function getDefaultSessionConfig(bridge: Bridge): Promise<AISessionConfig>
   return {
     provider: settings.activeProvider,
     model: null,
+    yoloMode: false,
   }
 }
 


### PR DESCRIPTION
## Summary

This PR prepares the next release by improving packaged-app and tool-call reliability, and adds an explicit dangerous auto-approve mode for command tool calls.

- Loads a full macOS desktop shell environment in packaged builds so Finder-launched apps can find tools like Codex, Claude, nvm, Bun, and Homebrew-installed binaries.
- Adds a durable `tool_state` event model for ACP/MCP tool calls, with pending/running/completed/error/rejected states, timestamps, structured command output previews, invalid-tool reporting, and cleanup for aborted runs.
- Adds per-chat YOLO mode with a red danger indicator in chat. When enabled, AI server-command tool calls are auto-approved for that chat.

## Details

- Adds an OpenCode-style packaged shell env probe using `env -0`, with interactive-login and login shell probing.
- Adds shared tool-state helpers for command output truncation, Paulus tool-name normalization, invalid tool states, and model-visible command result formatting.
- Routes ACP command approval/execution and MCP tool wrappers through structured state transitions instead of relying only on transient command events.
- Updates desktop/core orchestrators, CLI, provider self-test, chat rendering, terminal echo, and chat store handling to consume `tool_state`.
- Stores `yoloMode` in session config and auto-approves pending `server-command` tool states when enabled.

## Compatibility

Not backward compatible for live integrations that consume fresh `command_proposal`, `command_running`, `command_output`, or `command_done` events directly. New command/tool execution now emits `tool_state` as the primary event model. Historical session rendering still handles existing stored command events.

Session records now include `yoloMode`. Old sessions are normalized to `false` when loaded.

Command output sent back into chat/model context is now capped to a 20k-character preview; full SSH output remains available through the terminal stream/history path.

## Validation

- `bun test packages/ai/src/tool-state.test.js apps/desktop/src/main/shell-env.test.js`
- `bun run typecheck`
- `bun run --cwd apps/desktop build`
- `bun run build && bunx electron-builder --config electron-builder.yml -c.mac.identity=null`
- Commit hook: `bun run check`
