### PR TITLE
[codex] fix startup latency

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,8 +1,9 @@
 import { app, BrowserWindow, shell } from 'electron'
 import { join } from 'path'
-import { registerIPCHandlers } from './ipc'
+import { registerIPCHandlers, warmDesktopRuntime } from './ipc'
 import { initLogger } from './logger'
-import { syncDesktopShellEnv } from './shell-env'
+import { ensureDesktopShellEnv } from './shell-env'
+import { bootstrapDesktopApp } from './startup'
 import { initUpdater } from './updater'
 
 const isDev = !app.isPackaged
@@ -23,8 +24,6 @@ async function createWindow(): Promise<BrowserWindow> {
       sandbox: false,
     },
   })
-
-  await registerIPCHandlers(win)
 
   if (isDev) {
     // Forward main process logs to renderer DevTools console
@@ -54,11 +53,15 @@ async function createWindow(): Promise<BrowserWindow> {
 }
 
 app.whenReady().then(async () => {
-  if (app.isPackaged) {
-    syncDesktopShellEnv()
-  }
-
-  await createWindow()
+  await bootstrapDesktopApp({
+    isPackaged: app.isPackaged,
+    registerIPCHandlers,
+    warmRuntime: warmDesktopRuntime,
+    warmShellEnv: ensureDesktopShellEnv,
+    createWindow: async () => {
+      await createWindow()
+    },
+  })
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron'
-import type { BrowserWindow } from 'electron'
-import { createDesktopRuntime } from './runtime'
+import { createDesktopRuntime, type DesktopPaulusRuntime } from './runtime'
 import { testAIProvider } from './provider-self-test'
+import { ensureDesktopShellEnv } from './shell-env'
 import {
   checkForUpdates as checkUpdater,
   downloadUpdate as downloadUpdaterUpdate,
@@ -9,85 +9,151 @@ import {
   quitAndInstall,
 } from './updater'
 
-export async function registerIPCHandlers(win: BrowserWindow): Promise<void> {
-  const runtime = await createDesktopRuntime(win)
-  const { storage, settings, sessions, terminalSessions, serverManager, aiOrchestrator, appData } =
-    runtime
+let handlersRegistered = false
+let runtimePromise: Promise<DesktopPaulusRuntime> | null = null
+
+function getRuntime(): Promise<DesktopPaulusRuntime> {
+  if (!runtimePromise) {
+    runtimePromise = createDesktopRuntime()
+  }
+
+  return runtimePromise
+}
+
+function withRuntime<T>(fn: (runtime: DesktopPaulusRuntime) => Promise<T> | T): Promise<T> {
+  return getRuntime().then((runtime) => fn(runtime))
+}
+
+export function warmDesktopRuntime(): Promise<DesktopPaulusRuntime> {
+  return getRuntime()
+}
+
+export function registerIPCHandlers(): void {
+  if (handlersRegistered) {
+    return
+  }
+
+  handlersRegistered = true
 
   // Servers
-  ipcMain.handle('servers:list', () => serverManager.list())
-  ipcMain.handle('servers:add', (_, { config, password }) => serverManager.add(config, password))
+  ipcMain.handle('servers:list', () => withRuntime(({ serverManager }) => serverManager.list()))
+  ipcMain.handle('servers:add', (_, { config, password }) =>
+    withRuntime(({ serverManager }) => serverManager.add(config, password)),
+  )
   ipcMain.handle('servers:update', (_, { config, password }) =>
-    serverManager.update(config, password),
+    withRuntime(({ serverManager }) => serverManager.update(config, password)),
   )
   ipcMain.handle('servers:move', (_, { serverId, targetCategory, beforeServerId }) =>
-    serverManager.move(serverId, targetCategory, beforeServerId),
+    withRuntime(({ serverManager }) =>
+      serverManager.move(serverId, targetCategory, beforeServerId),
+    ),
   )
-  ipcMain.handle('servers:list-categories', () => serverManager.listCategories())
-  ipcMain.handle('servers:create-category', (_, name) => serverManager.createCategory(name))
+  ipcMain.handle('servers:list-categories', () =>
+    withRuntime(({ serverManager }) => serverManager.listCategories()),
+  )
+  ipcMain.handle('servers:create-category', (_, name) =>
+    withRuntime(({ serverManager }) => serverManager.createCategory(name)),
+  )
   ipcMain.handle('servers:rename-category', (_, { oldName, newName }) =>
-    serverManager.renameCategory(oldName, newName),
+    withRuntime(({ serverManager }) => serverManager.renameCategory(oldName, newName)),
   )
-  ipcMain.handle('servers:remove-category', (_, name) => serverManager.removeCategory(name))
-  ipcMain.handle('servers:remove', async (_, id) => {
-    await sessions.deleteForServer(id)
-    await serverManager.remove(id)
-  })
-  ipcMain.handle('servers:connect', (_, id) => serverManager.connect(id))
+  ipcMain.handle('servers:remove-category', (_, name) =>
+    withRuntime(({ serverManager }) => serverManager.removeCategory(name)),
+  )
+  ipcMain.handle('servers:remove', (_, id) =>
+    withRuntime(async ({ sessions, serverManager }) => {
+      await sessions.deleteForServer(id)
+      await serverManager.remove(id)
+    }),
+  )
+  ipcMain.handle('servers:connect', (_, id) =>
+    withRuntime(({ serverManager }) => serverManager.connect(id)),
+  )
   ipcMain.handle('servers:connect-with-password', (_, { id, password, save }) =>
-    serverManager.connectWithPassword(id, password, save),
+    withRuntime(({ serverManager }) => serverManager.connectWithPassword(id, password, save)),
   )
-  ipcMain.handle('servers:disconnect', (_, id) => serverManager.disconnect(id))
+  ipcMain.handle('servers:disconnect', (_, id) =>
+    withRuntime(({ serverManager }) => serverManager.disconnect(id)),
+  )
   ipcMain.handle('servers:exec', (_, { serverId, sessionId, command }) =>
-    serverManager.exec(serverId, sessionId, command),
+    withRuntime(({ serverManager }) => serverManager.exec(serverId, sessionId, command)),
   )
 
   // AI
-  ipcMain.handle('ai:send', (_, { serverId, sessionId, message }) =>
-    aiOrchestrator.send(serverId, sessionId, message),
-  )
+  ipcMain.handle('ai:send', async (_, { serverId, sessionId, message }) => {
+    await ensureDesktopShellEnv()
+    return withRuntime(({ aiOrchestrator }) => aiOrchestrator.send(serverId, sessionId, message))
+  })
   ipcMain.handle('ai:approve', (_, { sessionId, commandId }) =>
-    aiOrchestrator.approve(sessionId, commandId),
+    withRuntime(({ aiOrchestrator }) => aiOrchestrator.approve(sessionId, commandId)),
   )
   ipcMain.handle('ai:reject', (_, { sessionId, commandId }) =>
-    aiOrchestrator.reject(sessionId, commandId),
+    withRuntime(({ aiOrchestrator }) => aiOrchestrator.reject(sessionId, commandId)),
   )
-  ipcMain.handle('ai:providers', async () => {
-    const s = await settings.get()
-    return s.providers
+  ipcMain.handle('ai:providers', () =>
+    withRuntime(async ({ settings }) => {
+      const currentSettings = await settings.get()
+      return currentSettings.providers
+    }),
+  )
+  ipcMain.handle('ai:models', async (_, provider) => {
+    await ensureDesktopShellEnv()
+    return withRuntime(({ aiOrchestrator }) => aiOrchestrator.getModels(provider))
   })
-  ipcMain.handle('ai:models', (_, provider) => aiOrchestrator.getModels(provider))
 
   // Sessions
-  ipcMain.handle('sessions:list', (_, serverId) => sessions.list(serverId))
-  ipcMain.handle('sessions:get', (_, sessionId) => sessions.get(sessionId))
-  ipcMain.handle('sessions:create', (_, { serverId, config }) => sessions.create(serverId, config))
-  ipcMain.handle('sessions:update', (_, { sessionId, config }) =>
-    sessions.update(sessionId, config),
+  ipcMain.handle('sessions:list', (_, serverId) =>
+    withRuntime(({ sessions }) => sessions.list(serverId)),
   )
-  ipcMain.handle('sessions:delete', (_, sessionId) => sessions.delete(sessionId))
-  ipcMain.handle('terminals:get', (_, sessionId) => terminalSessions.get(sessionId))
-  ipcMain.handle('terminals:clear', (_, sessionId) => terminalSessions.clear(sessionId))
+  ipcMain.handle('sessions:get', (_, sessionId) =>
+    withRuntime(({ sessions }) => sessions.get(sessionId)),
+  )
+  ipcMain.handle('sessions:create', (_, { serverId, config }) =>
+    withRuntime(({ sessions }) => sessions.create(serverId, config)),
+  )
+  ipcMain.handle('sessions:update', (_, { sessionId, config }) =>
+    withRuntime(({ sessions }) => sessions.update(sessionId, config)),
+  )
+  ipcMain.handle('sessions:delete', (_, sessionId) =>
+    withRuntime(({ sessions }) => sessions.delete(sessionId)),
+  )
+  ipcMain.handle('terminals:get', (_, sessionId) =>
+    withRuntime(({ terminalSessions }) => terminalSessions.get(sessionId)),
+  )
+  ipcMain.handle('terminals:clear', (_, sessionId) =>
+    withRuntime(({ terminalSessions }) => terminalSessions.clear(sessionId)),
+  )
 
   // Settings
-  ipcMain.handle('settings:get', () => settings.get())
-  ipcMain.handle('settings:update', (_, partial) => settings.update(partial))
-  ipcMain.handle('settings:test-provider', (_, provider) => testAIProvider(provider))
+  ipcMain.handle('settings:get', () => withRuntime(({ settings }) => settings.get()))
+  ipcMain.handle('settings:update', (_, partial) =>
+    withRuntime(({ settings }) => settings.update(partial)),
+  )
+  ipcMain.handle('settings:test-provider', async (_, provider) => {
+    await ensureDesktopShellEnv()
+    return testAIProvider(provider)
+  })
 
   // App data
-  ipcMain.handle('app-data:overview', () => appData.getOverview())
-  ipcMain.handle('app-data:open-directory', () => appData.openDirectory())
-  ipcMain.handle('app-data:export-servers', () => appData.exportServers())
+  ipcMain.handle('app-data:overview', () => withRuntime(({ appData }) => appData.getOverview()))
+  ipcMain.handle('app-data:open-directory', () =>
+    withRuntime(({ appData }) => appData.openDirectory()),
+  )
+  ipcMain.handle('app-data:export-servers', () =>
+    withRuntime(({ appData }) => appData.exportServers()),
+  )
   ipcMain.handle('app-data:import-royal-tsx', (_, { documentPassword }) =>
-    appData.importRoyalTsx(documentPassword),
+    withRuntime(({ appData }) => appData.importRoyalTsx(documentPassword)),
   )
   ipcMain.handle('app-data:set-password-storage-mode', (_, mode) =>
-    appData.setPasswordStorageMode(mode),
+    withRuntime(({ appData }) => appData.setPasswordStorageMode(mode)),
   )
 
   // Storage
-  ipcMain.handle('storage:get', (_, key) => storage.get(key))
-  ipcMain.handle('storage:set', (_, { key, value }) => storage.set(key, value))
+  ipcMain.handle('storage:get', (_, key) => withRuntime(({ storage }) => storage.get(key)))
+  ipcMain.handle('storage:set', (_, { key, value }) =>
+    withRuntime(({ storage }) => storage.set(key, value)),
+  )
 
   // Updater
   ipcMain.handle('updater:get-state', () => getUpdaterState())

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1,4 +1,4 @@
-import { app, type BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { join } from 'path'
 import { createPaulusRuntime, type PaulusRuntime, type RuntimeEventSink } from '@paulus/core'
 import { AppDataManager } from './app-data-manager'
@@ -8,16 +8,23 @@ export interface DesktopPaulusRuntime extends PaulusRuntime {
   appData: AppDataManager
 }
 
-export async function createDesktopRuntime(win: BrowserWindow): Promise<DesktopPaulusRuntime> {
+function broadcast(channel: string, payload: unknown): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (window.isDestroyed()) continue
+    window.webContents.send(channel, payload)
+  }
+}
+
+export async function createDesktopRuntime(): Promise<DesktopPaulusRuntime> {
   const eventSink: RuntimeEventSink = {
     emitAIEvent(event) {
-      win.webContents.send('ai:event', event)
+      broadcast('ai:event', event)
     },
     emitSSHOutput(event) {
-      win.webContents.send('ssh:output', event)
+      broadcast('ssh:output', event)
     },
     emitConnectionStatus(status) {
-      win.webContents.send('server:connection-status', status)
+      broadcast('server:connection-status', status)
     },
   }
 

--- a/apps/desktop/src/main/shell-env.test.js
+++ b/apps/desktop/src/main/shell-env.test.js
@@ -11,10 +11,6 @@ describe('shell env bootstrap', () => {
     expect(buildDesktopShellEnvArgs()).toEqual(['-il', '-c', 'env -0'])
   })
 
-  test('can read the full environment from a login shell fallback', () => {
-    expect(buildDesktopShellEnvArgs('-l')).toEqual(['-l', '-c', 'env -0'])
-  })
-
   test('falls back to /bin/sh when SHELL is missing', () => {
     const originalShell = process.env.SHELL
     delete process.env.SHELL

--- a/apps/desktop/src/main/shell-env.ts
+++ b/apps/desktop/src/main/shell-env.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'child_process'
+import { spawn } from 'child_process'
 
 const SHELL_ENV_TIMEOUT_MS = 5000
 const SHELL_ENV_COMMAND = 'env -0'
@@ -8,7 +8,9 @@ type ShellEnvProbe =
   | { type: 'Timeout' }
   | { type: 'Unavailable' }
 
-type ShellEnvMode = '-il' | '-l'
+type ShellEnvMode = '-il'
+
+let shellEnvSyncPromise: Promise<void> | null = null
 
 export function getDesktopUserShell(): string {
   return process.env['SHELL'] || '/bin/sh'
@@ -48,49 +50,84 @@ export function mergeDesktopShellEnv(
   return merged
 }
 
-function probeDesktopShellEnv(shell: string, mode: ShellEnvMode): ShellEnvProbe {
-  const result = spawnSync(shell, buildDesktopShellEnvArgs(mode), {
-    env: process.env,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: SHELL_ENV_TIMEOUT_MS,
-    windowsHide: true,
+async function probeDesktopShellEnv(shell: string, mode: ShellEnvMode): Promise<ShellEnvProbe> {
+  return new Promise((resolve) => {
+    const child = spawn(shell, buildDesktopShellEnvArgs(mode), {
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+
+    const stdoutChunks: Buffer[] = []
+    const stderrChunks: Buffer[] = []
+    let settled = false
+
+    const finish = (probe: ShellEnvProbe): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutId)
+      resolve(probe)
+    }
+
+    const timeoutId = setTimeout(() => {
+      child.kill('SIGKILL')
+      finish({ type: 'Timeout' })
+    }, SHELL_ENV_TIMEOUT_MS)
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdoutChunks.push(chunk)
+    })
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk)
+    })
+
+    child.on('error', (error) => {
+      console.warn(`Failed to load shell environment from ${shell} ${mode}: ${error.message}`)
+      finish({ type: 'Unavailable' })
+    })
+
+    child.on('close', (code) => {
+      if (settled) {
+        return
+      }
+
+      if (code !== 0) {
+        const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
+        console.warn(
+          stderr
+            ? `Failed to load shell environment from ${shell} ${mode}: ${stderr}`
+            : `Failed to load shell environment from ${shell} ${mode}: exit code ${code}`,
+        )
+        finish({ type: 'Unavailable' })
+        return
+      }
+
+      const shellEnv = parseDesktopShellEnv(Buffer.concat(stdoutChunks))
+      if (Object.keys(shellEnv).length === 0) {
+        console.warn(
+          `Failed to load shell environment from ${shell} ${mode}: shell returned no variables.`,
+        )
+        finish({ type: 'Unavailable' })
+        return
+      }
+
+      if (!shellEnv['PATH']) {
+        console.warn(
+          `Failed to load shell environment from ${shell} ${mode}: shell returned no PATH.`,
+        )
+        finish({ type: 'Unavailable' })
+        return
+      }
+
+      finish({ type: 'Loaded', value: shellEnv })
+    })
   })
-
-  const error = result.error as NodeJS.ErrnoException | undefined
-  if (error) {
-    if (error.code === 'ETIMEDOUT') return { type: 'Timeout' }
-    console.warn(`Failed to load shell environment from ${shell} ${mode}: ${error.message}`)
-    return { type: 'Unavailable' }
-  }
-
-  if (result.status !== 0) {
-    const stderr = result.stderr.toString('utf8').trim()
-    console.warn(
-      stderr
-        ? `Failed to load shell environment from ${shell} ${mode}: ${stderr}`
-        : `Failed to load shell environment from ${shell} ${mode}: exit code ${result.status}`,
-    )
-    return { type: 'Unavailable' }
-  }
-
-  const shellEnv = parseDesktopShellEnv(result.stdout)
-  if (Object.keys(shellEnv).length === 0) {
-    console.warn(
-      `Failed to load shell environment from ${shell} ${mode}: shell returned no variables.`,
-    )
-    return { type: 'Unavailable' }
-  }
-
-  if (!shellEnv['PATH']) {
-    console.warn(`Failed to load shell environment from ${shell} ${mode}: shell returned no PATH.`)
-    return { type: 'Unavailable' }
-  }
-
-  return { type: 'Loaded', value: shellEnv }
 }
 
-export function loadDesktopShellEnv(shell: string): Record<string, string> | null {
-  const interactive = probeDesktopShellEnv(shell, '-il')
+export async function loadDesktopShellEnv(shell: string): Promise<Record<string, string> | null> {
+  const interactive = await probeDesktopShellEnv(shell, '-il')
+
   if (interactive.type === 'Loaded') {
     return interactive.value
   }
@@ -102,23 +139,24 @@ export function loadDesktopShellEnv(shell: string): Record<string, string> | nul
     return null
   }
 
-  const login = probeDesktopShellEnv(shell, '-l')
-  if (login.type === 'Loaded') {
-    return login.value
-  }
-
   console.warn(`Shell environment probe failed for ${shell}. Using app environment.`)
   return null
 }
 
-export function syncDesktopShellEnv(): void {
+export async function ensureDesktopShellEnv(): Promise<void> {
   if (process.platform !== 'darwin') {
     return
   }
 
-  const shell = getDesktopUserShell()
-  const env = mergeDesktopShellEnv(loadDesktopShellEnv(shell), process.env)
-  for (const [key, value] of Object.entries(env)) {
-    process.env[key] = value
+  if (!shellEnvSyncPromise) {
+    shellEnvSyncPromise = (async () => {
+      const shell = getDesktopUserShell()
+      const env = mergeDesktopShellEnv(await loadDesktopShellEnv(shell), process.env)
+      for (const [key, value] of Object.entries(env)) {
+        process.env[key] = value
+      }
+    })()
   }
+
+  await shellEnvSyncPromise
 }

--- a/apps/desktop/src/main/startup.test.js
+++ b/apps/desktop/src/main/startup.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+import { bootstrapDesktopApp } from './startup'
+
+function createDeferred() {
+  let resolve
+  const promise = new Promise((nextResolve) => {
+    resolve = nextResolve
+  })
+
+  return { promise, resolve }
+}
+
+describe('desktop startup bootstrap', () => {
+  test('does not wait for runtime warming before the window can finish loading', async () => {
+    const runtime = createDeferred()
+    const calls = []
+
+    await bootstrapDesktopApp({
+      isPackaged: false,
+      registerIPCHandlers() {
+        calls.push('register')
+      },
+      warmRuntime() {
+        calls.push('runtime:start')
+        return runtime.promise
+      },
+      warmShellEnv() {
+        calls.push('shell:start')
+        return Promise.resolve()
+      },
+      async createWindow() {
+        calls.push('window:create')
+      },
+    })
+
+    expect(calls).toEqual(['register', 'window:create', 'runtime:start'])
+    runtime.resolve()
+  })
+
+  test('starts packaged shell env warming without blocking window creation', async () => {
+    const runtime = createDeferred()
+    const shellEnv = createDeferred()
+    const calls = []
+
+    await bootstrapDesktopApp({
+      isPackaged: true,
+      registerIPCHandlers() {
+        calls.push('register')
+      },
+      warmRuntime() {
+        calls.push('runtime:start')
+        return runtime.promise
+      },
+      warmShellEnv() {
+        calls.push('shell:start')
+        return shellEnv.promise
+      },
+      async createWindow() {
+        calls.push('window:create')
+      },
+    })
+
+    expect(calls).toEqual(['register', 'window:create', 'runtime:start', 'shell:start'])
+    runtime.resolve()
+    shellEnv.resolve()
+  })
+})

--- a/apps/desktop/src/main/startup.ts
+++ b/apps/desktop/src/main/startup.ts
@@ -1,0 +1,30 @@
+export interface StartupHooks {
+  createWindow(): Promise<void>
+  registerIPCHandlers(): void
+  warmRuntime(): Promise<unknown>
+  warmShellEnv(): Promise<void>
+  isPackaged: boolean
+}
+
+export async function bootstrapDesktopApp({
+  createWindow,
+  registerIPCHandlers,
+  warmRuntime,
+  warmShellEnv,
+  isPackaged,
+}: StartupHooks): Promise<void> {
+  registerIPCHandlers()
+  const windowPromise = createWindow()
+
+  void warmRuntime().catch((error) => {
+    console.error('[startup] Runtime warmup failed:', error)
+  })
+
+  if (isPackaged) {
+    void warmShellEnv().catch((error) => {
+      console.error('[startup] Shell env warmup failed:', error)
+    })
+  }
+
+  await windowPromise
+}


### PR DESCRIPTION
## What changed
- decoupled Electron window loading from desktop runtime warmup so the renderer can start loading immediately
- moved desktop runtime creation behind a shared lazy promise and registered IPC handlers up front
- replaced the blocking macOS shell environment bootstrap with an async on-demand warmup
- added startup regression tests for non-blocking window creation and updated shell env coverage

## Why
App launch was spending time on main-process work before the window even started loading. In packaged macOS builds, shell environment probing also blocked startup on a synchronous interactive shell spawn.

## Impact
- faster perceived startup because the window begins loading before runtime initialization completes
- provider and AI actions still wait for shell env hydration when they actually need it
- startup behavior is now covered by tests so future regressions are easier to catch

## Root cause
The main process awaited runtime setup during `createWindow()`, and packaged builds synchronously probed the user shell before creating the first window.

## Validation
- `bun test apps/desktop/src/main/startup.test.js apps/desktop/src/main/shell-env.test.js`
- `bun run typecheck`
- `bun run dev` smoke boot

## Compatibility
This removes the previous `-l` shell probe fallback after the `-il` interactive probe fails. If an environment previously relied on that fallback, provider CLI discovery will now fail instead of retrying with `-l`.
