### PR TITLE
[codex] add multi-server chat workflow

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -178,7 +178,7 @@ async function resolveSession(
 ): Promise<string> {
   if (explicitSessionId) {
     const session = await runtime.sessions.get(explicitSessionId)
-    if (session.serverId !== serverId) {
+    if (!session.serverIds.includes(serverId)) {
       throw new Error(`Session ${explicitSessionId} does not belong to the selected server`)
     }
     return session.id
@@ -191,7 +191,7 @@ async function resolveSession(
   }
 
   const settings = await runtime.settings.get()
-  const session = await runtime.sessions.create(serverId, {
+  const session = await runtime.sessions.create([serverId], {
     provider: settings.activeProvider,
     model: null,
     yoloMode: false,
@@ -440,7 +440,7 @@ async function runChatSend(
         options.sessionId,
         options.newSession,
       )
-      await runtimeRef.current.aiOrchestrator.send(server.id, activeSessionId, message)
+      await runtimeRef.current.aiOrchestrator.send([server.id], activeSessionId, message)
     })().catch((err) => {
       reject(err instanceof Error ? err : new Error(String(err)))
     })

--- a/apps/desktop/src/main/ai-orchestrator.ts
+++ b/apps/desktop/src/main/ai-orchestrator.ts
@@ -17,6 +17,7 @@ interface PendingCommand {
   id: string
   command: string
   serverId: string
+  serverName: string
   sessionId: string
   startedAt: string
 }
@@ -52,11 +53,27 @@ export class AIOrchestrator {
     return provider.listModels()
   }
 
-  async send(serverId: string, sessionId: string, message: string): Promise<void> {
+  async send(serverIds: string[], sessionId: string, message: string): Promise<void> {
     const session = await this.sessionManager.get(sessionId)
-    const serverConfig = this.serverManager.getConfig(serverId)
-    if (!serverConfig) throw new Error(`Server not found: ${serverId}`)
     const yoloMode = session.yoloMode === true
+
+    // Build server contexts for all servers in this session
+    const serverContexts = serverIds.map((sid) => {
+      const config = this.serverManager.getConfig(sid)
+      if (!config) throw new Error(`Server not found: ${sid}`)
+      return {
+        id: sid,
+        name: config.name,
+        host: config.host,
+        port: config.port,
+        username: config.username,
+        authMethod: config.authMethod as 'password' | 'key',
+        hasStoredPassword: Boolean(config.hasPassword),
+        privateKeyPath: config.privateKeyPath,
+        tags: config.tags ?? [],
+        connected: this.serverManager.pool.isConnected(sid),
+      }
+    })
 
     // Save user message
     const userMessage: AIMessage = {
@@ -75,22 +92,13 @@ export class AIOrchestrator {
     history.push({ role: 'user', content: message })
 
     // Spawn AI process
-    console.log(`[AI] Spawning ${session.provider} for server ${serverConfig.name}`)
+    const serverNamesList = serverContexts.map((s) => s.name).join(', ')
+    console.log(`[AI] Spawning ${session.provider} for servers: ${serverNamesList}`)
     const provider = createProvider(session.provider)
     const process = provider.spawn(
       message,
       {
-        server: {
-          name: serverConfig.name,
-          host: serverConfig.host,
-          port: serverConfig.port,
-          username: serverConfig.username,
-          authMethod: serverConfig.authMethod,
-          hasStoredPassword: Boolean(serverConfig.hasPassword),
-          privateKeyPath: serverConfig.privateKeyPath,
-          tags: serverConfig.tags ?? [],
-          connected: this.serverManager.pool.isConnected(serverId),
-        },
+        servers: serverContexts,
         conversationHistory: history,
       },
       { model: session.model },
@@ -125,10 +133,19 @@ export class AIOrchestrator {
             event.tool.status === 'pending' &&
             event.tool.command
           ) {
+            // Resolve server name from tool metadata to serverId
+            const targetServerName =
+              (event.tool.metadata?.serverName as string) ?? serverContexts[0]?.name
+            const targetServer = serverContexts.find(
+              (s) => s.name.toLowerCase() === targetServerName?.toLowerCase(),
+            )
+            const targetServerId = targetServer?.id ?? serverIds[0]
+
             this.pendingCommands.set(event.tool.id, {
               id: event.tool.id,
               command: event.tool.command,
-              serverId,
+              serverId: targetServerId,
+              serverName: targetServerName ?? '',
               sessionId,
               startedAt: event.tool.startedAt ?? new Date().toISOString(),
             })
@@ -182,6 +199,8 @@ export class AIOrchestrator {
           command: pending.command,
           status: 'running',
           startedAt: pending.startedAt,
+          serverId: pending.serverId,
+          serverName: pending.serverName,
         }),
       ),
     )
@@ -199,6 +218,8 @@ export class AIOrchestrator {
             startedAt: pending.startedAt,
             endedAt: new Date().toISOString(),
             output: createCommandToolOutput(result),
+            serverId: pending.serverId,
+            serverName: pending.serverName,
           }),
         ),
       )
@@ -219,6 +240,8 @@ export class AIOrchestrator {
             startedAt: pending.startedAt,
             endedAt: new Date().toISOString(),
             error: `Command failed: ${err.message}`,
+            serverId: pending.serverId,
+            serverName: pending.serverName,
           }),
         ),
       )
@@ -229,7 +252,7 @@ export class AIOrchestrator {
           formatCommandResultForModel({
             exitCode: 1,
             stdout: '',
-            stderr: `Command failed: ${err.message}`,
+            stderr: `Command failed on ${pending.serverName}: ${err.message}`,
           }),
         )
       }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { ipcMain, nativeTheme } from 'electron'
 import { createDesktopRuntime, type DesktopPaulusRuntime } from './runtime'
 import { testAIProvider } from './provider-self-test'
 import { ensureDesktopShellEnv } from './shell-env'
@@ -80,15 +80,18 @@ export function registerIPCHandlers(): void {
   )
 
   // AI
-  ipcMain.handle('ai:send', async (_, { serverId, sessionId, message }) => {
+  ipcMain.handle('ai:send', async (_, { serverIds, sessionId, message }) => {
     await ensureDesktopShellEnv()
-    return withRuntime(({ aiOrchestrator }) => aiOrchestrator.send(serverId, sessionId, message))
+    return withRuntime(({ aiOrchestrator }) => aiOrchestrator.send(serverIds, sessionId, message))
   })
   ipcMain.handle('ai:approve', (_, { sessionId, commandId }) =>
     withRuntime(({ aiOrchestrator }) => aiOrchestrator.approve(sessionId, commandId)),
   )
   ipcMain.handle('ai:reject', (_, { sessionId, commandId }) =>
     withRuntime(({ aiOrchestrator }) => aiOrchestrator.reject(sessionId, commandId)),
+  )
+  ipcMain.handle('ai:kill', (_, { sessionId }) =>
+    withRuntime(({ aiOrchestrator }) => aiOrchestrator.kill(sessionId)),
   )
   ipcMain.handle('ai:providers', () =>
     withRuntime(async ({ settings }) => {
@@ -108,8 +111,8 @@ export function registerIPCHandlers(): void {
   ipcMain.handle('sessions:get', (_, sessionId) =>
     withRuntime(({ sessions }) => sessions.get(sessionId)),
   )
-  ipcMain.handle('sessions:create', (_, { serverId, config }) =>
-    withRuntime(({ sessions }) => sessions.create(serverId, config)),
+  ipcMain.handle('sessions:create', (_, { serverIds, config }) =>
+    withRuntime(({ sessions }) => sessions.create(serverIds, config)),
   )
   ipcMain.handle('sessions:update', (_, { sessionId, config }) =>
     withRuntime(({ sessions }) => sessions.update(sessionId, config)),
@@ -125,10 +128,18 @@ export function registerIPCHandlers(): void {
   )
 
   // Settings
-  ipcMain.handle('settings:get', () => withRuntime(({ settings }) => settings.get()))
-  ipcMain.handle('settings:update', (_, partial) =>
-    withRuntime(({ settings }) => settings.update(partial)),
-  )
+  ipcMain.handle('settings:get', async () => {
+    const s = await withRuntime(({ settings }) => settings.get())
+    nativeTheme.themeSource = s.theme
+    return s
+  })
+  ipcMain.handle('settings:update', async (_, partial) => {
+    const updated = await withRuntime(({ settings }) => settings.update(partial))
+    if (partial.theme) {
+      nativeTheme.themeSource = partial.theme
+    }
+    return updated
+  })
   ipcMain.handle('settings:test-provider', async (_, provider) => {
     await ensureDesktopShellEnv()
     return testAIProvider(provider)

--- a/apps/desktop/src/main/provider-self-test.ts
+++ b/apps/desktop/src/main/provider-self-test.ts
@@ -7,16 +7,19 @@ const TEST_SERVER_NAME = 'Settings Self-Test'
 
 function createTestContext(): AIContext {
   return {
-    server: {
-      name: TEST_SERVER_NAME,
-      host: '127.0.0.1',
-      port: 22,
-      username: 'paulus',
-      authMethod: 'key',
-      hasStoredPassword: false,
-      tags: ['settings', 'self-test'],
-      connected: false,
-    },
+    servers: [
+      {
+        id: 'self-test',
+        name: TEST_SERVER_NAME,
+        host: '127.0.0.1',
+        port: 22,
+        username: 'paulus',
+        authMethod: 'key',
+        hasStoredPassword: false,
+        tags: ['settings', 'self-test'],
+        connected: false,
+      },
+    ],
     conversationHistory: [],
   }
 }

--- a/apps/desktop/src/main/session-manager.ts
+++ b/apps/desktop/src/main/session-manager.ts
@@ -10,6 +10,7 @@ export class SessionManager {
     this.storage = storage
   }
 
+  /** List sessions that include this serverId */
   async list(serverId: string): Promise<AISession[]> {
     const index = await this.storage.get<string[]>(`sessions-index-${serverId}`)
     if (!index) return []
@@ -27,10 +28,10 @@ export class SessionManager {
     return this.normalizeSession(session)
   }
 
-  async create(serverId: string, config: AISessionConfig): Promise<AISession> {
+  async create(serverIds: string[], config: AISessionConfig): Promise<AISession> {
     const session: AISession = {
       id: randomUUID(),
-      serverId,
+      serverIds,
       messages: [],
       provider: config.provider,
       model: config.model,
@@ -40,9 +41,14 @@ export class SessionManager {
     }
     await this.save(session)
 
-    const index = (await this.storage.get<string[]>(`sessions-index-${serverId}`)) ?? []
-    index.push(session.id)
-    await this.storage.set(`sessions-index-${serverId}`, index)
+    // Index under each server so the session appears when listing any of its servers
+    for (const serverId of serverIds) {
+      const index = (await this.storage.get<string[]>(`sessions-index-${serverId}`)) ?? []
+      if (!index.includes(session.id)) {
+        index.push(session.id)
+        await this.storage.set(`sessions-index-${serverId}`, index)
+      }
+    }
 
     return session
   }
@@ -64,10 +70,38 @@ export class SessionManager {
     await this.save(session)
   }
 
+  async deleteForServer(serverId: string): Promise<void> {
+    const index = await this.storage.get<string[]>(`sessions-index-${serverId}`)
+    if (!index) return
+    for (const id of index) {
+      await this.storage.remove(`session-${id}`)
+    }
+    await this.storage.remove(`sessions-index-${serverId}`)
+  }
+
+  async delete(sessionId: string): Promise<void> {
+    const session = await this.storage.get<AISession>(`session-${sessionId}`)
+    if (!session) return
+    const normalized = await this.normalizeSession(session)
+    // Remove from all server indexes
+    for (const sid of normalized.serverIds) {
+      const index = await this.storage.get<string[]>(`sessions-index-${sid}`)
+      if (index) {
+        const filtered = index.filter((id) => id !== sessionId)
+        await this.storage.set(`sessions-index-${sid}`, filtered)
+      }
+    }
+    await this.storage.remove(`session-${sessionId}`)
+  }
+
   private async save(session: AISession): Promise<void> {
     await this.storage.set(`session-${session.id}`, session)
   }
 
+  /**
+   * Normalize a session — handles backward compatibility from old
+   * single-server sessions (serverId) to new multi-server (serverIds).
+   */
   private async normalizeSession(session: AISession): Promise<AISession> {
     const normalizedProvider = isAIProviderType(session.provider)
       ? session.provider
@@ -75,20 +109,32 @@ export class SessionManager {
     const normalizedModel = typeof session.model === 'string' ? session.model : null
     const normalizedYoloMode = session.yoloMode === true
 
-    if (
-      normalizedProvider === session.provider &&
-      normalizedModel === session.model &&
-      normalizedYoloMode === session.yoloMode
-    ) {
+    // Migrate old serverId → serverIds
+    let serverIds = session.serverIds
+    if (!serverIds || serverIds.length === 0) {
+      const legacyServerId = (session as any).serverId as string | undefined
+      serverIds = legacyServerId ? [legacyServerId] : []
+    }
+
+    const needsUpdate =
+      normalizedProvider !== session.provider ||
+      normalizedModel !== session.model ||
+      normalizedYoloMode !== session.yoloMode ||
+      serverIds !== session.serverIds
+
+    if (!needsUpdate) {
       return session
     }
 
     const normalizedSession: AISession = {
       ...session,
+      serverIds,
       provider: normalizedProvider,
       model: normalizedModel,
       yoloMode: normalizedYoloMode,
     }
+    // Clean up legacy field
+    delete normalizedSession.serverId
     await this.save(normalizedSession)
     return normalizedSession
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -31,12 +31,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     onOutput: (cb: any) => onEvent('ssh:output', cb),
   },
   ai: {
-    send: (serverId: string, sessionId: string, message: string) =>
-      ipcRenderer.invoke('ai:send', { serverId, sessionId, message }),
+    send: (serverIds: string[], sessionId: string, message: string) =>
+      ipcRenderer.invoke('ai:send', { serverIds, sessionId, message }),
     approve: (sessionId: string, commandId: string) =>
       ipcRenderer.invoke('ai:approve', { sessionId, commandId }),
     reject: (sessionId: string, commandId: string) =>
       ipcRenderer.invoke('ai:reject', { sessionId, commandId }),
+    kill: (sessionId: string) => ipcRenderer.invoke('ai:kill', { sessionId }),
     getProviders: () => ipcRenderer.invoke('ai:providers'),
     getModels: (provider: string) => ipcRenderer.invoke('ai:models', provider),
     onEvent: (cb: any) => onEvent('ai:event', cb),
@@ -45,9 +46,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     list: (serverId: string) => ipcRenderer.invoke('sessions:list', serverId),
     get: (sessionId: string) => ipcRenderer.invoke('sessions:get', sessionId),
     create: (
-      serverId: string,
+      serverIds: string[],
       config: { provider: string; model: string | null; yoloMode: boolean },
-    ) => ipcRenderer.invoke('sessions:create', { serverId, config }),
+    ) => ipcRenderer.invoke('sessions:create', { serverIds, config }),
     update: (
       sessionId: string,
       config: { provider: string; model: string | null; yoloMode: boolean },

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -1,7 +1,80 @@
 @import 'tailwindcss';
 @source "../../../../packages/ui/src/**/*.tsx";
 
-/* assistant-ui markdown prose styling */
+/* Class-based dark mode for accent color overrides */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* ─── Theme tokens ─── */
+:root {
+  /* Surfaces */
+  --th-surface: #ffffff;
+  --th-surface-alt: #fafafa;
+  --th-surface-raised: #f4f4f5;
+  --th-surface-active: #e4e4e7;
+  --th-surface-strong: #d4d4d8;
+  --th-surface-invert: #27272a;
+  --th-surface-invert-hover: #3f3f46;
+
+  /* Foreground */
+  --th-fg: #18181b;
+  --th-fg-secondary: #3f3f46;
+  --th-fg-tertiary: #52525b;
+  --th-fg-muted: #a1a1aa;
+  --th-fg-faint: #71717a;
+  --th-fg-dim: #a1a1aa;
+  --th-fg-invert: #f4f4f5;
+
+  /* Edges */
+  --th-edge: #d4d4d8;
+  --th-edge-subtle: #e4e4e7;
+  --th-edge-strong: #a1a1aa;
+}
+
+.dark {
+  --th-surface: #09090b;
+  --th-surface-alt: #18181b;
+  --th-surface-raised: #27272a;
+  --th-surface-active: #3f3f46;
+  --th-surface-strong: #52525b;
+  --th-surface-invert: #f4f4f5;
+  --th-surface-invert-hover: #e4e4e7;
+
+  --th-fg: #f4f4f5;
+  --th-fg-secondary: #e4e4e7;
+  --th-fg-tertiary: #d4d4d8;
+  --th-fg-muted: #a1a1aa;
+  --th-fg-faint: #71717a;
+  --th-fg-dim: #52525b;
+  --th-fg-invert: #18181b;
+
+  --th-edge: #3f3f46;
+  --th-edge-subtle: #27272a;
+  --th-edge-strong: #52525b;
+}
+
+@theme {
+  --color-surface: var(--th-surface);
+  --color-surface-alt: var(--th-surface-alt);
+  --color-surface-raised: var(--th-surface-raised);
+  --color-surface-active: var(--th-surface-active);
+  --color-surface-strong: var(--th-surface-strong);
+  --color-surface-invert: var(--th-surface-invert);
+  --color-surface-invert-hover: var(--th-surface-invert-hover);
+
+  --color-fg: var(--th-fg);
+  --color-fg-secondary: var(--th-fg-secondary);
+  --color-fg-tertiary: var(--th-fg-tertiary);
+  --color-fg-muted: var(--th-fg-muted);
+  --color-fg-faint: var(--th-fg-faint);
+  --color-fg-dim: var(--th-fg-dim);
+  --color-fg-invert: var(--th-fg-invert);
+
+  --color-edge: var(--th-edge);
+  --color-edge-subtle: var(--th-edge-subtle);
+  --color-edge-strong: var(--th-edge-strong);
+}
+
+/* ─── assistant-ui markdown prose styling ─── */
 .aui-md-root {
   @apply text-sm leading-relaxed overflow-x-auto;
 }
@@ -11,11 +84,11 @@
 }
 
 .aui-md-root pre {
-  @apply my-2 rounded-lg bg-zinc-950 p-3 overflow-x-auto text-xs;
+  @apply my-2 rounded-lg bg-surface p-3 overflow-x-auto text-xs;
 }
 
 .aui-md-root code:not(pre code) {
-  @apply rounded bg-zinc-800 px-1.5 py-0.5 text-xs font-mono text-zinc-200;
+  @apply rounded bg-surface-raised px-1.5 py-0.5 text-xs font-mono text-fg-secondary;
 }
 
 .aui-md-root ul,
@@ -38,7 +111,7 @@
 .aui-md-root h1,
 .aui-md-root h2,
 .aui-md-root h3 {
-  @apply font-semibold mt-3 mb-1 text-zinc-100;
+  @apply font-semibold mt-3 mb-1 text-fg;
 }
 
 .aui-md-root a {
@@ -46,7 +119,7 @@
 }
 
 .aui-md-root blockquote {
-  @apply border-l-2 border-zinc-700 pl-3 my-2 text-zinc-400;
+  @apply border-l-2 border-edge pl-3 my-2 text-fg-muted;
 }
 
 .aui-md-root table {
@@ -54,22 +127,22 @@
 }
 
 .aui-md-root thead {
-  @apply bg-zinc-900/80;
+  @apply bg-surface-alt/80;
 }
 
 .aui-md-root th,
 .aui-md-root td {
-  @apply border border-zinc-800 px-2 py-1 align-top whitespace-nowrap;
+  @apply border border-edge-subtle px-2 py-1 align-top whitespace-nowrap;
 }
 
 .aui-md-root th {
-  @apply text-left font-medium text-zinc-100;
+  @apply text-left font-medium text-fg;
 }
 
 .aui-md-root td {
-  @apply text-zinc-300;
+  @apply text-fg-tertiary;
 }
 
 .aui-md-root hr {
-  @apply my-3 border-zinc-800;
+  @apply my-3 border-edge-subtle;
 }

--- a/packages/ai/src/context.ts
+++ b/packages/ai/src/context.ts
@@ -1,61 +1,119 @@
-import type { AIContext } from './provider'
+import type { AIContext, AIServerContext } from './provider'
+
+function formatServerDetails(server: AIServerContext): string {
+  return [
+    `- Name: ${server.name}`,
+    `- Host/IP: ${server.host}`,
+    `- Port: ${server.port}`,
+    `- SSH username: ${server.username}`,
+    `- Auth method: ${server.authMethod}`,
+    `- Stored password available in Paulus: ${server.hasStoredPassword ? 'yes' : 'no'}`,
+    `- Private key path: ${server.privateKeyPath ?? 'not configured'}`,
+    `- Tags: ${server.tags.length > 0 ? server.tags.join(', ') : 'none'}`,
+    `- Connection status in Paulus: ${server.connected ? 'connected' : 'disconnected'}`,
+  ].join('\n')
+}
 
 export function buildSystemPrompt(context: AIContext): string {
-  const serverDetails = [
-    `- Name: ${context.server.name}`,
-    `- Host/IP: ${context.server.host}`,
-    `- Port: ${context.server.port}`,
-    `- SSH username: ${context.server.username}`,
-    `- Auth method: ${context.server.authMethod}`,
-    `- Stored password available in Paulus: ${context.server.hasStoredPassword ? 'yes' : 'no'}`,
-    `- Private key path: ${context.server.privateKeyPath ?? 'not configured'}`,
-    `- Tags: ${context.server.tags.length > 0 ? context.server.tags.join(', ') : 'none'}`,
-    `- Connection status in Paulus: ${context.server.connected ? 'connected' : 'disconnected'}`,
-  ]
+  const servers = context.servers
+  const isMultiServer = servers.length > 1
+  const serverNames = servers.map((s) => `"${s.name}"`)
 
   const parts = [
     `You are an AI assistant embedded in Paulus Orchestrator, a server management desktop app.`,
-    `Every user message in this conversation is about the remote server described below — not your local environment, not the user's laptop, not a hypothetical server.`,
-    ``,
-    `Selected server:`,
-    ...serverDetails,
+  ]
+
+  if (isMultiServer) {
+    parts.push(
+      `This session has access to ${servers.length} remote servers. The user may ask you to work across multiple servers — for example, setting up replication, copying data between servers, or comparing configurations.`,
+      ``,
+      `Available servers:`,
+    )
+    for (const server of servers) {
+      parts.push(``, `### ${server.name}`, formatServerDetails(server))
+    }
+  } else {
+    parts.push(
+      `Every user message in this conversation is about the remote server described below — not your local environment, not the user's laptop, not a hypothetical server.`,
+      ``,
+      `Selected server:`,
+      formatServerDetails(servers[0]),
+    )
+  }
+
+  parts.push(
     ``,
     `## MANDATORY TOOL USE`,
     ``,
-    `You have access to MCP tools provided by Paulus. You MUST use them to answer ANY question about the server's current state. This is non-negotiable.`,
+    `You have access to MCP tools provided by Paulus. You MUST use them to answer ANY question about server state. This is non-negotiable.`,
     ``,
     `Available MCP tools:`,
-    `- paulus_exec_server_command — Execute a shell command on the remote server. Takes a single "command" string argument. THIS IS YOUR PRIMARY TOOL. Use it for every server inspection.`,
-    `- paulus_get_server_context — Returns server metadata Paulus already knows (name, host, auth method, etc.).`,
+  )
+
+  if (isMultiServer) {
+    parts.push(
+      `- paulus_exec_server_command — Execute a shell command on a remote server. Takes "server" (the server name) and "command" (shell command) arguments. You MUST specify which server to target. Available servers: ${serverNames.join(', ')}.`,
+      `- paulus_get_server_context — Returns server metadata Paulus already knows. Takes an optional "server" name; omit to get all servers.`,
+    )
+  } else {
+    parts.push(
+      `- paulus_exec_server_command — Execute a shell command on the remote server. Takes "server" (use "${servers[0].name}") and "command" (shell command) arguments. THIS IS YOUR PRIMARY TOOL.`,
+      `- paulus_get_server_context — Returns server metadata Paulus already knows.`,
+    )
+  }
+
+  parts.push(
     ``,
     `CRITICAL RULES:`,
-    `1. For ANY question about the server (processes, disk, memory, CPU, logs, services, packages, files, ports, users, OS, uptime, configs, network, docker, etc.) — you MUST call paulus_exec_server_command FIRST before responding. Do NOT answer from your own knowledge.`,
+    `1. For ANY question about a server (processes, disk, memory, CPU, logs, services, packages, files, ports, users, OS, uptime, configs, network, docker, etc.) — you MUST call paulus_exec_server_command FIRST before responding. Do NOT answer from your own knowledge.`,
     `2. NEVER guess, assume, or fabricate server state. If you haven't run a command to check, you don't know.`,
-    `3. NEVER use your local/host/sandbox environment as evidence about the remote server.`,
+    `3. NEVER use your local/host/sandbox environment as evidence about a remote server.`,
     `4. NEVER ask the user to SSH manually, paste output, or provide credentials — Paulus handles all of that.`,
     `5. NEVER wrap commands in "ssh user@host ..." — Paulus executes directly on the server.`,
-    `6. Run ONE command at a time, wait for its result, then proceed.`,
+    `6. Run ONE command at a time per server, wait for its result, then proceed.`,
     `7. After getting command output, analyze it and answer the user's question based on that real data.`,
     `8. Be cautious with destructive operations (rm -rf, DROP, etc.) — flag them clearly before executing.`,
     `9. For multi-step tasks, explain the plan first, then propose commands one by one.`,
-    `10. If the server is disconnected, tell the user to connect it in Paulus before you can inspect it.`,
-    `11. Default to the selected remote server for any ambiguous inspection request. Only switch to the local machine/workspace if the user explicitly says local, host machine, macOS, laptop, workspace, or current repo.`,
+    `10. If a server is disconnected, tell the user to connect it in Paulus before you can inspect it.`,
+    `11. Default to the remote server(s) for any ambiguous inspection request. Only switch to the local machine/workspace if the user explicitly says local, host machine, macOS, laptop, workspace, or current repo.`,
     `12. For remote inspection, use paulus_exec_server_command. Do not use built-in Bash, terminal, shell, exec, or local runtime tools unless the user explicitly requested local execution.`,
+  )
+
+  if (isMultiServer) {
+    parts.push(
+      `13. ALWAYS specify the "server" argument when calling paulus_exec_server_command. If the user's request is ambiguous about which server, ask for clarification or run on all relevant servers.`,
+      `14. When working across servers, clearly indicate which server each command is targeting and which server produced each output.`,
+    )
+  }
+
+  parts.push(
     ``,
     `## Response pattern`,
     ``,
     `When the user asks about server state, your response MUST follow this pattern:`,
     `1. Briefly acknowledge what they want to know`,
-    `2. IMMEDIATELY call paulus_exec_server_command with the appropriate command`,
+    `2. IMMEDIATELY call paulus_exec_server_command with the appropriate command${isMultiServer ? ' and target server' : ''}`,
     `3. After receiving the result, summarize the findings from the actual command output`,
     ``,
     `Examples:`,
-    `- "what processes are running?" → call paulus_exec_server_command with "ps aux --sort=-%cpu | head -20"`,
-    `- "what linux is this?" → call paulus_exec_server_command with "cat /etc/os-release && uname -srmo"`,
-    `- "how much disk space?" → call paulus_exec_server_command with "df -h"`,
-    `- "check nginx status" → call paulus_exec_server_command with "systemctl status nginx"`,
-    `- "what's using port 8080?" → call paulus_exec_server_command with "ss -tlnp | grep 8080"`,
-  ]
+  )
+
+  if (isMultiServer) {
+    const exampleServer = servers[0].name
+    parts.push(
+      `- "what processes are running on ${exampleServer}?" → call paulus_exec_server_command with server="${exampleServer}", command="ps aux --sort=-%cpu | head -20"`,
+      `- "compare disk space across servers" → call paulus_exec_server_command on each server with command="df -h"`,
+      `- "setup replication from A to B" → explain plan, then execute steps on each server in order`,
+    )
+  } else {
+    parts.push(
+      `- "what processes are running?" → call paulus_exec_server_command with server="${servers[0].name}", command="ps aux --sort=-%cpu | head -20"`,
+      `- "what linux is this?" → call paulus_exec_server_command with server="${servers[0].name}", command="cat /etc/os-release && uname -srmo"`,
+      `- "how much disk space?" → call paulus_exec_server_command with server="${servers[0].name}", command="df -h"`,
+      `- "check nginx status" → call paulus_exec_server_command with server="${servers[0].name}", command="systemctl status nginx"`,
+      `- "what's using port 8080?" → call paulus_exec_server_command with server="${servers[0].name}", command="ss -tlnp | grep 8080"`,
+    )
+  }
 
   if (context.systemInfo) {
     parts.push(``, `System info:\n${context.systemInfo}`)

--- a/packages/ai/src/execution-scope.ts
+++ b/packages/ai/src/execution-scope.ts
@@ -78,7 +78,7 @@ export function buildInspectionInstruction(prompt: string): string | null {
     return (
       'MANDATORY TOOL USE FOR THIS REQUEST: ' +
       `${scopeInstruction} ` +
-      'Call paulus_exec_server_command with exactly "cat /etc/os-release && uname -srmo" before any answer. ' +
+      'Call paulus_exec_server_command with the target server name and command "cat /etc/os-release && uname -srmo" before any answer. ' +
       'Do not answer from local runtime context. An answer without that tool result is invalid.'
     )
   }

--- a/packages/ai/src/paulus-mcp-server.ts
+++ b/packages/ai/src/paulus-mcp-server.ts
@@ -133,7 +133,9 @@ function registerTools(mcpServer: McpServer, options: McpToolServerOptions): voi
           }
         }
 
-        console.log(`[MCP] paulus_exec_server_command: server=${matched.name} command=${command.slice(0, 120)}`)
+        console.log(
+          `[MCP] paulus_exec_server_command: server=${matched.name} command=${command.slice(0, 120)}`,
+        )
         const result = await options.executeCommand(matched.name, command)
         return {
           content: [

--- a/packages/ai/src/paulus-mcp-server.ts
+++ b/packages/ai/src/paulus-mcp-server.ts
@@ -13,8 +13,8 @@ export interface CommandExecutionResult {
 }
 
 interface McpToolServerOptions {
-  server: AIServerContext
-  executeCommand(command: string): Promise<CommandExecutionResult>
+  servers: AIServerContext[]
+  executeCommand(serverName: string, command: string): Promise<CommandExecutionResult>
   onToolCall?: (toolName: string, args: Record<string, unknown>) => void
 }
 
@@ -65,57 +65,134 @@ function defineMcpTool<TArgs extends Record<string, unknown>>(
 }
 
 function registerTools(mcpServer: McpServer, options: McpToolServerOptions): void {
-  const commandSchema: z.ZodType<{ command: string }> = z.object({
-    command: z.string().min(1).describe('Shell command to run on the selected remote server'),
+  const serverNames = options.servers.map((s) => s.name)
+  const isSingleServer = options.servers.length === 1
+  const defaultServerName = isSingleServer ? options.servers[0].name : undefined
+
+  const commandSchema = z.object({
+    server: z
+      .string()
+      .describe(
+        isSingleServer
+          ? `Target server name. Available: "${serverNames[0]}"`
+          : `Target server name. Available: ${serverNames.map((n) => `"${n}"`).join(', ')}`,
+      ),
+    command: z.string().min(1).describe('Shell command to run on the target remote server'),
   })
-  const emptySchema: z.ZodType<Record<string, never>> = z.object({})
+
+  const contextSchema = z.object({
+    server: z
+      .string()
+      .optional()
+      .describe(
+        isSingleServer
+          ? `Server name (optional, defaults to "${serverNames[0]}")`
+          : `Server name. If omitted, returns info for all servers. Available: ${serverNames.map((n) => `"${n}"`).join(', ')}`,
+      ),
+  })
 
   mcpServer.registerTool(
     'paulus_exec_server_command',
     {
       description:
-        'Execute a shell command on the selected remote server through Paulus Orchestrator.',
+        options.servers.length === 1
+          ? `Execute a shell command on the remote server "${serverNames[0]}" through Paulus Orchestrator.`
+          : `Execute a shell command on a remote server through Paulus Orchestrator. You MUST specify which server to target. Available servers: ${serverNames.map((n) => `"${n}"`).join(', ')}.`,
       inputSchema: commandSchema,
     },
-    defineMcpTool('paulus_exec_server_command', commandSchema, options, async ({ command }) => {
-      const result = await options.executeCommand(command)
-      return {
-        content: [
-          {
-            type: 'text',
-            text:
-              `Command: ${command}\n` +
-              `Exit code: ${result.exitCode}\n` +
-              `STDOUT:\n${result.stdout || '(empty)'}\n` +
-              `STDERR:\n${result.stderr || '(empty)'}`,
-          },
-        ],
-      }
-    }),
+    defineMcpTool(
+      'paulus_exec_server_command',
+      commandSchema,
+      options,
+      async ({ server, command }) => {
+        const targetName = server || defaultServerName
+        if (!targetName) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `You must specify which server to target. Available servers: ${serverNames.map((n) => `"${n}"`).join(', ')}`,
+              },
+            ],
+          }
+        }
+
+        const matched = options.servers.find(
+          (s) => s.name.toLowerCase() === targetName.toLowerCase(),
+        )
+        if (!matched) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Server "${targetName}" not found. Available servers: ${serverNames.map((n) => `"${n}"`).join(', ')}`,
+              },
+            ],
+          }
+        }
+
+        console.log(`[MCP] paulus_exec_server_command: server=${matched.name} command=${command.slice(0, 120)}`)
+        const result = await options.executeCommand(matched.name, command)
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                `Server: ${matched.name}\n` +
+                `Command: ${command}\n` +
+                `Exit code: ${result.exitCode}\n` +
+                `STDOUT:\n${result.stdout || '(empty)'}\n` +
+                `STDERR:\n${result.stderr || '(empty)'}`,
+            },
+          ],
+        }
+      },
+    ),
   )
 
   mcpServer.registerTool(
     'paulus_get_server_context',
     {
-      description: 'Return the selected server metadata Paulus already knows.',
-      inputSchema: emptySchema,
+      description:
+        options.servers.length === 1
+          ? 'Return the server metadata Paulus already knows.'
+          : 'Return server metadata Paulus already knows. Optionally specify a server name, or omit to get all.',
+      inputSchema: contextSchema,
     },
-    defineMcpTool('paulus_get_server_context', emptySchema, options, async () => {
-      const server = options.server
+    defineMcpTool('paulus_get_server_context', contextSchema, options, async ({ server }) => {
+      const targets = server
+        ? options.servers.filter((s) => s.name.toLowerCase() === server.toLowerCase())
+        : options.servers
+
+      if (targets.length === 0) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Server "${server}" not found. Available servers: ${serverNames.map((n) => `"${n}"`).join(', ')}`,
+            },
+          ],
+        }
+      }
+
+      const text = targets
+        .map(
+          (s) =>
+            `Name: ${s.name}\n` +
+            `Host/IP: ${s.host}\n` +
+            `Port: ${s.port}\n` +
+            `Username: ${s.username}\n` +
+            `Auth method: ${s.authMethod}\n` +
+            `Connected in Paulus: ${s.connected ? 'yes' : 'no'}\n` +
+            `Tags: ${s.tags.join(', ') || 'none'}`,
+        )
+        .join('\n\n---\n\n')
+
       return {
-        content: [
-          {
-            type: 'text',
-            text:
-              `Name: ${server.name}\n` +
-              `Host/IP: ${server.host}\n` +
-              `Port: ${server.port}\n` +
-              `Username: ${server.username}\n` +
-              `Auth method: ${server.authMethod}\n` +
-              `Connected in Paulus: ${server.connected ? 'yes' : 'no'}\n` +
-              `Tags: ${server.tags.join(', ') || 'none'}`,
-          },
-        ],
+        content: [{ type: 'text', text }],
       }
     }),
   )
@@ -185,6 +262,8 @@ export class PaulusMcpServer {
   }
 
   private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    console.log(`[MCP] ${req.method} ${req.url} session=${req.headers['mcp-session-id'] ?? 'none'}`)
+
     if (!req.url || !req.url.startsWith('/mcp')) {
       res.statusCode = 404
       res.end('Not found')

--- a/packages/ai/src/provider.ts
+++ b/packages/ai/src/provider.ts
@@ -3,6 +3,7 @@ import { ClaudeAcpProvider } from './providers/claude-acp'
 import { CodexAcpProvider } from './providers/codex-acp'
 
 export interface AIServerContext {
+  id: string
   name: string
   host: string
   port: number
@@ -15,7 +16,8 @@ export interface AIServerContext {
 }
 
 export interface AIContext {
-  server: AIServerContext
+  /** All servers available in this session */
+  servers: AIServerContext[]
   systemInfo?: string
   conversationHistory: Array<{ role: 'user' | 'assistant'; content: string }>
   onPaulusToolCall?: (toolName: string, args: Record<string, unknown>) => void

--- a/packages/ai/src/providers/acp-base.ts
+++ b/packages/ai/src/providers/acp-base.ts
@@ -357,8 +357,7 @@ export abstract class AcpBaseProvider implements AIProvider {
 
       // Options may live at params.options or permission.options depending on agent
       const allowOption =
-        this.findPermissionOption(permission, 'allow') ??
-        this.findPermissionOption(params, 'allow')
+        this.findPermissionOption(permission, 'allow') ?? this.findPermissionOption(params, 'allow')
       const rejectOption =
         this.findPermissionOption(permission, 'reject') ??
         this.findPermissionOption(params, 'reject')
@@ -378,7 +377,9 @@ export abstract class AcpBaseProvider implements AIProvider {
         // For Paulus tools, always grant permission. Try the matched allow option
         // first, then fall back to any available option (agents use varying names).
         const option =
-          allowOption ?? this.findFirstPermissionOption(permission) ?? this.findFirstPermissionOption(params)
+          allowOption ??
+          this.findFirstPermissionOption(permission) ??
+          this.findFirstPermissionOption(params)
         if (option) {
           return Promise.resolve({
             outcome: {
@@ -882,9 +883,7 @@ export abstract class AcpBaseProvider implements AIProvider {
     }
   }
 
-  private findFirstPermissionOption(
-    permission: any,
-  ): { optionId: string; kind?: string } | null {
+  private findFirstPermissionOption(permission: any): { optionId: string; kind?: string } | null {
     const options: Array<{ optionId?: string; kind?: string }> = Array.isArray(permission?.options)
       ? permission.options
       : []

--- a/packages/ai/src/providers/acp-base.ts
+++ b/packages/ai/src/providers/acp-base.ts
@@ -23,6 +23,7 @@ import {
 interface PendingToolCall {
   commandId: string
   command: string
+  serverName: string
   startedAt: string
   resolve: (result: { stdout: string; stderr: string; exitCode: number }) => void
   reject: (err: Error) => void
@@ -107,16 +108,20 @@ export abstract class AcpBaseProvider implements AIProvider {
     let eventResolve: (() => void) | null = null
     let finished = false
     const paulusMcpServer = new PaulusMcpServer({
-      server: context.server,
+      servers: context.servers,
       onToolCall: context.onPaulusToolCall,
-      executeCommand: async (command) => {
+      executeCommand: async (serverName, command) => {
         return new Promise((resolve, reject) => {
           const cmdId = randomUUID()
           const startedAt = new Date().toISOString()
+          const matchedServer = context.servers.find(
+            (s) => s.name.toLowerCase() === serverName.toLowerCase(),
+          )
 
           pendingToolCalls.set(cmdId, {
             commandId: cmdId,
             command,
+            serverName,
             startedAt,
             resolve,
             reject,
@@ -129,8 +134,11 @@ export abstract class AcpBaseProvider implements AIProvider {
                 command,
                 status: 'pending',
                 startedAt,
-                explanation:
-                  'AI wants Paulus to run a command on the selected server via paulus_exec_server_command',
+                explanation: `AI wants Paulus to run a command on "${serverName}" via paulus_exec_server_command`,
+                metadata: {
+                  serverId: matchedServer?.id,
+                  serverName,
+                },
               }),
             ),
           )
@@ -273,10 +281,12 @@ export abstract class AcpBaseProvider implements AIProvider {
             const command = this.extractCommand(params)
             const cmdId = randomUUID()
             const startedAt = new Date().toISOString()
+            const defaultServerName = context.servers[0]?.name ?? ''
 
             pendingToolCalls.set(cmdId, {
               commandId: cmdId,
               command,
+              serverName: defaultServerName,
               startedAt,
               resolve: (result) => {
                 resolve({
@@ -344,12 +354,49 @@ export abstract class AcpBaseProvider implements AIProvider {
     client.onRequest('session/request_permission', (params) => {
       const permission = params?.permission || params || {}
       const toolName = this.getToolName('session/request_permission', permission)
-      const allowOption = this.findPermissionOption(permission, 'allow')
-      const rejectOption = this.findPermissionOption(permission, 'reject')
+
+      // Options may live at params.options or permission.options depending on agent
+      const allowOption =
+        this.findPermissionOption(permission, 'allow') ??
+        this.findPermissionOption(params, 'allow')
+      const rejectOption =
+        this.findPermissionOption(permission, 'reject') ??
+        this.findPermissionOption(params, 'reject')
+
+      console.log(
+        `[${this.name}] request_permission: tool=${toolName} allow=${allowOption?.optionId ?? 'null'} reject=${rejectOption?.optionId ?? 'null'}`,
+      )
 
       // Default to remote-only unless the user explicitly requested local execution.
+      // The Codex agent sends a generic "Approve MCP tool call" title for MCP tools
+      // instead of the specific tool name. Since we only configure our own Paulus MCP
+      // server, approve any MCP-related permission request — the actual tool execution
+      // still goes through the command approval flow.
       const isPaulusTool = isPaulusToolName(toolName)
-      if (isPaulusTool && allowOption) {
+      const isMcpToolPermission = toolName.toLowerCase().includes('mcp')
+      if (isPaulusTool || isMcpToolPermission) {
+        // For Paulus tools, always grant permission. Try the matched allow option
+        // first, then fall back to any available option (agents use varying names).
+        const option =
+          allowOption ?? this.findFirstPermissionOption(permission) ?? this.findFirstPermissionOption(params)
+        if (option) {
+          return Promise.resolve({
+            outcome: {
+              outcome: 'selected',
+              optionId: option.optionId,
+            },
+          })
+        }
+        console.warn(
+          `[${this.name}] Paulus tool "${toolName}" permission request had no selectable options — cancelling`,
+        )
+      }
+
+      // Allow shell tools through permission so they reach the execution handler.
+      // In remote scope the execution handler returns a helpful error redirecting
+      // the agent to use paulus_exec_server_command via MCP instead of silently
+      // cancelling the request here with no guidance.
+      if (isLocalShellToolName(toolName) && allowOption) {
         return Promise.resolve({
           outcome: {
             outcome: 'selected',
@@ -358,16 +405,7 @@ export abstract class AcpBaseProvider implements AIProvider {
         })
       }
 
-      if (executionScope === 'local' && isLocalShellToolName(toolName) && allowOption) {
-        return Promise.resolve({
-          outcome: {
-            outcome: 'selected',
-            optionId: allowOption.optionId,
-          },
-        })
-      }
-
-      // Reject everything else (built-in Bash, terminal, file tools, etc.)
+      // Reject everything else (file system tools, etc.)
       if (rejectOption) {
         return Promise.resolve({
           outcome: {
@@ -818,11 +856,21 @@ export abstract class AcpBaseProvider implements AIProvider {
     const options: Array<{ optionId?: string; kind?: string }> = Array.isArray(permission?.options)
       ? permission.options
       : []
+
+    // Agents use varying option names: allow/approve/always_allow, reject/deny/block etc.
+    const allowSynonyms = ['allow', 'approve', 'accept', 'grant', 'yes']
+    const rejectSynonyms = ['reject', 'deny', 'decline', 'block', 'refuse', 'no']
+    const synonyms = kind === 'allow' ? allowSynonyms : rejectSynonyms
+
     const matchingOption =
-      options.find((option) => typeof option?.kind === 'string' && option.kind.startsWith(kind)) ??
-      options.find(
-        (option) => typeof option?.optionId === 'string' && option.optionId.includes(kind),
-      )
+      options.find((option) => {
+        const k = typeof option?.kind === 'string' ? option.kind.toLowerCase() : ''
+        return synonyms.some((syn) => k.startsWith(syn) || k.includes(syn))
+      }) ??
+      options.find((option) => {
+        const id = typeof option?.optionId === 'string' ? option.optionId.toLowerCase() : ''
+        return synonyms.some((syn) => id.includes(syn))
+      })
 
     if (!matchingOption || typeof matchingOption.optionId !== 'string') {
       return null
@@ -832,6 +880,17 @@ export abstract class AcpBaseProvider implements AIProvider {
       optionId: matchingOption.optionId,
       kind: matchingOption.kind,
     }
+  }
+
+  private findFirstPermissionOption(
+    permission: any,
+  ): { optionId: string; kind?: string } | null {
+    const options: Array<{ optionId?: string; kind?: string }> = Array.isArray(permission?.options)
+      ? permission.options
+      : []
+    const first = options.find((option) => typeof option?.optionId === 'string')
+    if (!first || typeof first.optionId !== 'string') return null
+    return { optionId: first.optionId, kind: first.kind }
   }
 
   private pickString(...values: unknown[]): string | null {

--- a/packages/ai/src/tool-state.ts
+++ b/packages/ai/src/tool-state.ts
@@ -93,8 +93,12 @@ export function buildServerCommandToolState(
     explanation?: string
     output?: AICommandToolOutput
     error?: string
+    serverId?: string
+    serverName?: string
   },
 ): AIToolState {
+  const serverName = input.serverName ?? input.metadata?.serverName as string | undefined
+  const serverId = input.serverId ?? input.metadata?.serverId as string | undefined
   return {
     id: input.id,
     toolName: PAULUS_SERVER_COMMAND_TOOL,
@@ -102,7 +106,7 @@ export function buildServerCommandToolState(
     status: input.status,
     args: input.args ?? { command: input.command },
     argsText: input.argsText ?? JSON.stringify({ command: input.command }, null, 2),
-    title: input.title ?? 'Run On Server',
+    title: serverName ? `Run On ${serverName}` : 'Run On Server',
     command: input.command,
     explanation: input.explanation,
     output: input.output,
@@ -111,6 +115,8 @@ export function buildServerCommandToolState(
     startedAt: input.startedAt,
     endedAt: input.endedAt,
     metadata: input.metadata,
+    serverId,
+    serverName,
   }
 }
 

--- a/packages/ai/src/tool-state.ts
+++ b/packages/ai/src/tool-state.ts
@@ -97,8 +97,8 @@ export function buildServerCommandToolState(
     serverName?: string
   },
 ): AIToolState {
-  const serverName = input.serverName ?? input.metadata?.serverName as string | undefined
-  const serverId = input.serverId ?? input.metadata?.serverId as string | undefined
+  const serverName = input.serverName ?? (input.metadata?.serverName as string | undefined)
+  const serverId = input.serverId ?? (input.metadata?.serverId as string | undefined)
   return {
     id: input.id,
     toolName: PAULUS_SERVER_COMMAND_TOOL,

--- a/packages/bridge/src/electron.ts
+++ b/packages/bridge/src/electron.ts
@@ -24,9 +24,10 @@ export function createElectronBridge(): Bridge {
       onOutput: (cb) => api.servers.onOutput(cb),
     },
     ai: {
-      send: (serverId, sessionId, message) => api.ai.send(serverId, sessionId, message),
+      send: (serverIds, sessionId, message) => api.ai.send(serverIds, sessionId, message),
       approve: (sessionId, commandId) => api.ai.approve(sessionId, commandId),
       reject: (sessionId, commandId) => api.ai.reject(sessionId, commandId),
+      kill: (sessionId) => api.ai.kill(sessionId),
       getProviders: () => api.ai.getProviders(),
       getModels: (provider) => api.ai.getModels(provider),
       onEvent: (cb) => api.ai.onEvent(cb),
@@ -34,7 +35,7 @@ export function createElectronBridge(): Bridge {
     sessions: {
       list: (serverId) => api.sessions.list(serverId),
       get: (sessionId) => api.sessions.get(sessionId),
-      create: (serverId, config) => api.sessions.create(serverId, config),
+      create: (serverIds, config) => api.sessions.create(serverIds, config),
       update: (sessionId, config) => api.sessions.update(sessionId, config),
       delete: (sessionId) => api.sessions.delete(sessionId),
     },

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -50,9 +50,10 @@ export interface Bridge {
   }
 
   ai: {
-    send(serverId: string, sessionId: string, message: string): Promise<void>
+    send(serverIds: string[], sessionId: string, message: string): Promise<void>
     approve(sessionId: string, commandId: string): Promise<void>
     reject(sessionId: string, commandId: string): Promise<void>
+    kill(sessionId: string): Promise<void>
     getProviders(): Promise<AIProviderConfig[]>
     getModels(provider: AIProviderType): Promise<AIModelOption[]>
     onEvent(cb: (event: AIEvent & { sessionId: string }) => void): () => void
@@ -61,7 +62,7 @@ export interface Bridge {
   sessions: {
     list(serverId: string): Promise<AISession[]>
     get(sessionId: string): Promise<AISession>
-    create(serverId: string, config: AISessionConfig): Promise<AISession>
+    create(serverIds: string[], config: AISessionConfig): Promise<AISession>
     update(sessionId: string, config: AISessionConfig): Promise<AISession>
     delete(sessionId: string): Promise<void>
   }

--- a/packages/bridge/src/web.ts
+++ b/packages/bridge/src/web.ts
@@ -27,6 +27,7 @@ export function createWebBridge(): Bridge {
       send: notImplemented,
       approve: notImplemented,
       reject: notImplemented,
+      kill: notImplemented,
       getProviders: notImplemented,
       getModels: notImplemented,
       onEvent: notImplemented,

--- a/packages/core/src/ai-orchestrator.ts
+++ b/packages/core/src/ai-orchestrator.ts
@@ -18,6 +18,7 @@ interface PendingCommand {
   id: string
   command: string
   serverId: string
+  serverName: string
   sessionId: string
   startedAt: string
 }
@@ -45,11 +46,27 @@ export class AIOrchestrator {
     return provider.listModels()
   }
 
-  async send(serverId: string, sessionId: string, message: string): Promise<void> {
+  async send(serverIds: string[], sessionId: string, message: string): Promise<void> {
     const session = await this.sessionManager.get(sessionId)
-    const serverConfig = this.serverManager.getConfig(serverId)
-    if (!serverConfig) throw new Error(`Server not found: ${serverId}`)
     const yoloMode = session.yoloMode === true
+
+    // Build server contexts for all servers in this session
+    const serverContexts = serverIds.map((sid) => {
+      const config = this.serverManager.getConfig(sid)
+      if (!config) throw new Error(`Server not found: ${sid}`)
+      return {
+        id: sid,
+        name: config.name,
+        host: config.host,
+        port: config.port,
+        username: config.username,
+        authMethod: config.authMethod as 'password' | 'key',
+        hasStoredPassword: Boolean(config.hasPassword),
+        privateKeyPath: config.privateKeyPath,
+        tags: config.tags ?? [],
+        connected: this.serverManager.pool.isConnected(sid),
+      }
+    })
 
     const userMessage: AIMessage = {
       id: randomUUID(),
@@ -69,17 +86,7 @@ export class AIOrchestrator {
     const process = provider.spawn(
       message,
       {
-        server: {
-          name: serverConfig.name,
-          host: serverConfig.host,
-          port: serverConfig.port,
-          username: serverConfig.username,
-          authMethod: serverConfig.authMethod,
-          hasStoredPassword: Boolean(serverConfig.hasPassword),
-          privateKeyPath: serverConfig.privateKeyPath,
-          tags: serverConfig.tags ?? [],
-          connected: this.serverManager.pool.isConnected(serverId),
-        },
+        servers: serverContexts,
         conversationHistory: history,
       },
       { model: session.model },
@@ -101,10 +108,19 @@ export class AIOrchestrator {
             event.tool.status === 'pending' &&
             event.tool.command
           ) {
+            // Resolve server name from tool metadata to serverId
+            const targetServerName =
+              (event.tool.metadata?.serverName as string) ?? serverContexts[0]?.name
+            const targetServer = serverContexts.find(
+              (s) => s.name.toLowerCase() === targetServerName?.toLowerCase(),
+            )
+            const targetServerId = targetServer?.id ?? serverIds[0]
+
             this.pendingCommands.set(event.tool.id, {
               id: event.tool.id,
               command: event.tool.command,
-              serverId,
+              serverId: targetServerId,
+              serverName: targetServerName ?? '',
               sessionId,
               startedAt: event.tool.startedAt ?? new Date().toISOString(),
             })
@@ -155,6 +171,8 @@ export class AIOrchestrator {
           command: pending.command,
           status: 'running',
           startedAt: pending.startedAt,
+          serverId: pending.serverId,
+          serverName: pending.serverName,
         }),
       ),
     )
@@ -176,6 +194,8 @@ export class AIOrchestrator {
             startedAt: pending.startedAt,
             endedAt: new Date().toISOString(),
             output: createCommandToolOutput(result),
+            serverId: pending.serverId,
+            serverName: pending.serverName,
           }),
         ),
       )
@@ -196,7 +216,9 @@ export class AIOrchestrator {
             status: 'error',
             startedAt: pending.startedAt,
             endedAt: new Date().toISOString(),
-            error: `Command failed: ${message}`,
+            error: `Command failed on ${pending.serverName}: ${message}`,
+            serverId: pending.serverId,
+            serverName: pending.serverName,
           }),
         ),
       )
@@ -207,7 +229,7 @@ export class AIOrchestrator {
           formatCommandResultForModel({
             exitCode: 1,
             stdout: '',
-            stderr: `Command failed: ${message}`,
+            stderr: `Command failed on ${pending.serverName}: ${message}`,
           }),
         )
       }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -34,10 +34,14 @@ export class SessionManager {
     return this.normalizeSession(session)
   }
 
-  async create(serverId: string, config: AISessionConfig): Promise<AISession> {
+  async create(serverIds: string[], config: AISessionConfig): Promise<AISession> {
+    // Use first server as the primary for storage keying
+    const primaryServerId = serverIds[0]
+    if (!primaryServerId) throw new Error('At least one server is required')
+
     const session: AISession = {
       id: randomUUID(),
-      serverId,
+      serverIds,
       messages: [],
       provider: config.provider,
       model: config.model,
@@ -47,12 +51,17 @@ export class SessionManager {
     }
     await this.save(session)
 
-    const index = (await this.storage.get<string[]>(this.serverIndexKey(serverId))) ?? []
-    index.push(session.id)
-    await this.storage.set(this.serverIndexKey(serverId), index)
+    // Index under each server so the session is visible from any of them
+    for (const serverId of serverIds) {
+      const index = (await this.storage.get<string[]>(this.serverIndexKey(serverId))) ?? []
+      if (!index.includes(session.id)) {
+        index.push(session.id)
+        await this.storage.set(this.serverIndexKey(serverId), index)
+      }
+    }
 
     const lookup = (await this.storage.get<SessionLookupIndex>(this.globalIndexKey())) ?? {}
-    lookup[session.id] = serverId
+    lookup[session.id] = primaryServerId
     await this.storage.set(this.globalIndexKey(), lookup)
 
     return session
@@ -122,7 +131,8 @@ export class SessionManager {
   }
 
   private async save(session: AISession): Promise<void> {
-    await this.storage.set(this.sessionKey(session.serverId, session.id), session)
+    const primaryServerId = session.serverIds[0] ?? (session as any).serverId
+    await this.storage.set(this.sessionKey(primaryServerId, session.id), session)
   }
 
   private async normalizeSession(session: AISession): Promise<AISession> {
@@ -132,20 +142,31 @@ export class SessionManager {
     const normalizedModel = typeof session.model === 'string' ? session.model : null
     const normalizedYoloMode = session.yoloMode === true
 
-    if (
-      normalizedProvider === session.provider &&
-      normalizedModel === session.model &&
-      normalizedYoloMode === session.yoloMode
-    ) {
+    // Migrate old serverId → serverIds
+    let serverIds = session.serverIds
+    if (!serverIds || serverIds.length === 0) {
+      const legacyServerId = (session as any).serverId as string | undefined
+      serverIds = legacyServerId ? [legacyServerId] : []
+    }
+
+    const needsUpdate =
+      normalizedProvider !== session.provider ||
+      normalizedModel !== session.model ||
+      normalizedYoloMode !== session.yoloMode ||
+      serverIds !== session.serverIds
+
+    if (!needsUpdate) {
       return session
     }
 
     const normalizedSession: AISession = {
       ...session,
+      serverIds,
       provider: normalizedProvider,
       model: normalizedModel,
       yoloMode: normalizedYoloMode,
     }
+    delete normalizedSession.serverId
     await this.save(normalizedSession)
     return normalizedSession
   }

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -73,6 +73,9 @@ export interface AIToolState {
   metadata?: Record<string, unknown>
   startedAt?: string
   endedAt?: string
+  /** Which server this command targets (for multi-server sessions) */
+  serverId?: string
+  serverName?: string
 }
 
 export type AIEvent =
@@ -110,7 +113,12 @@ export interface AIMessage {
 
 export interface AISession {
   id: string
-  serverId: string
+  /**
+   * @deprecated Use `serverIds` instead. Kept for backward compatibility with stored sessions.
+   */
+  serverId?: string
+  /** All servers available to this chat session */
+  serverIds: string[]
   messages: AIMessage[]
   provider: AIProviderType
   model: string | null

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -5,6 +5,12 @@ import { Sidebar } from './components/layout/sidebar'
 import { MainPanel } from './components/layout/main-panel'
 import { UpdateBanner } from './components/layout/update-banner'
 
+function applyTheme(theme: 'light' | 'dark' | 'system') {
+  const isDark =
+    theme === 'dark' || (theme === 'system' && matchMedia('(prefers-color-scheme: dark)').matches)
+  document.documentElement.classList.toggle('dark', isDark)
+}
+
 export function App() {
   const bridge = useBridge()
   const initServers = useServerStore((s) => s.init)
@@ -12,6 +18,20 @@ export function App() {
   const initLayout = useLayoutStore((s) => s.init)
   const initUpdater = useUpdaterStore((s) => s.init)
   const sidebarCollapsed = useLayoutStore((s) => s.sidebarCollapsed)
+  const theme = useSettingsStore((s) => s.settings?.theme)
+
+  // Apply theme class to <html> and listen for system preference changes
+  useEffect(() => {
+    const current = theme ?? 'dark'
+    applyTheme(current)
+
+    if (current !== 'system') return
+
+    const mq = matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => applyTheme('system')
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [theme])
 
   useEffect(() => {
     initServers(bridge).catch(() => {})
@@ -30,7 +50,7 @@ export function App() {
   }, [])
 
   return (
-    <div className="h-screen w-screen bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden">
+    <div className="h-screen w-screen bg-surface text-fg flex flex-col overflow-hidden">
       <UpdateBanner />
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {!sidebarCollapsed && <Sidebar />}

--- a/packages/ui/src/components/approval/approval-banner.tsx
+++ b/packages/ui/src/components/approval/approval-banner.tsx
@@ -19,11 +19,11 @@ export function ApprovalBanner({ commands, onApprove, onReject }: ApprovalBanner
             <span className="text-xs text-yellow-500 font-medium mt-0.5 flex-shrink-0">
               COMMAND
             </span>
-            <code className="text-sm text-zinc-200 bg-zinc-800 px-2 py-1 rounded font-mono flex-1 break-all">
+            <code className="text-sm text-fg-secondary bg-surface-raised px-2 py-1 rounded font-mono flex-1 break-all">
               {cmd.command}
             </code>
           </div>
-          {cmd.explanation && <p className="text-xs text-zinc-400 pl-16">{cmd.explanation}</p>}
+          {cmd.explanation && <p className="text-xs text-fg-muted pl-16">{cmd.explanation}</p>}
           <div className="flex gap-2 pl-16">
             <button
               onClick={() => onApprove(cmd.id)}
@@ -33,7 +33,7 @@ export function ApprovalBanner({ commands, onApprove, onReject }: ApprovalBanner
             </button>
             <button
               onClick={() => onReject(cmd.id)}
-              className="text-xs px-3 py-1.5 bg-zinc-700 text-zinc-300 rounded hover:bg-zinc-600"
+              className="text-xs px-3 py-1.5 bg-surface-active text-fg-tertiary rounded hover:bg-surface-strong"
             >
               Reject
             </button>

--- a/packages/ui/src/components/chat/chat-input.tsx
+++ b/packages/ui/src/components/chat/chat-input.tsx
@@ -35,7 +35,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
   }
 
   return (
-    <div className="border-t border-zinc-800 p-4">
+    <div className="border-t border-edge-subtle p-4">
       <div className="flex gap-2 items-end">
         <textarea
           ref={textareaRef}
@@ -48,12 +48,12 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
           disabled={disabled}
           rows={1}
           placeholder={disabled ? 'Waiting for AI response...' : 'Ask about this server...'}
-          className="flex-1 bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 resize-none focus:outline-none focus:border-zinc-500 disabled:opacity-50"
+          className="flex-1 bg-surface-raised border border-edge rounded-lg px-4 py-2.5 text-sm text-fg placeholder-fg-faint resize-none focus:outline-none focus:border-edge-strong disabled:opacity-50"
         />
         <button
           onClick={handleSubmit}
           disabled={disabled || !value.trim()}
-          className="px-4 py-2.5 text-sm bg-zinc-100 text-zinc-900 rounded-lg hover:bg-zinc-200 disabled:opacity-30 disabled:cursor-not-allowed"
+          className="px-4 py-2.5 text-sm bg-surface-invert text-fg-invert rounded-lg hover:bg-surface-invert-hover disabled:opacity-30 disabled:cursor-not-allowed"
         >
           Send
         </button>

--- a/packages/ui/src/components/chat/chat-view.tsx
+++ b/packages/ui/src/components/chat/chat-view.tsx
@@ -57,10 +57,7 @@ export function ChatView({ serverId, isConnected, connectionStatus }: ChatViewPr
   const runtime = useAssistantRuntime(sessionServerIds)
   const sessionForServer = activeSession?.serverIds.includes(serverId) ? activeSession : null
   const serverNamesList = useMemo(
-    () =>
-      sessionServerIds
-        .map((id) => servers.find((s) => s.id === id)?.name ?? id)
-        .join(', '),
+    () => sessionServerIds.map((id) => servers.find((s) => s.id === id)?.name ?? id).join(', '),
     [sessionServerIds, servers],
   )
   const selectedConfig: AISessionConfig | null = sessionForServer
@@ -105,7 +102,13 @@ export function ChatView({ serverId, isConnected, connectionStatus }: ChatViewPr
           </div>
         ) : null}
 
-        <Thread serverId={serverId} isConnected={isConnected} isMultiServer={isMultiServer} debugMode={debugMode} setDebugMode={setDebugMode} />
+        <Thread
+          serverId={serverId}
+          isConnected={isConnected}
+          isMultiServer={isMultiServer}
+          debugMode={debugMode}
+          setDebugMode={setDebugMode}
+        />
       </div>
     </AssistantRuntimeProvider>
   )
@@ -148,7 +151,13 @@ function Thread({
       {debugMode && <SessionDebugPanel />}
 
       <PendingCommandBar isConnected={isConnected} />
-      <Composer serverId={serverId} isConnected={isConnected} isMultiServer={isMultiServer} debugMode={debugMode} setDebugMode={setDebugMode} />
+      <Composer
+        serverId={serverId}
+        isConnected={isConnected}
+        isMultiServer={isMultiServer}
+        debugMode={debugMode}
+        setDebugMode={setDebugMode}
+      />
     </ThreadPrimitive.Root>
   )
 }
@@ -206,7 +215,13 @@ function SessionDebugPanel() {
           messages: session.messages,
         }
       : null,
-    streaming: isStreaming ? { textLength: streamingText.length, eventCount: streamingEvents.length, events: streamingEvents } : null,
+    streaming: isStreaming
+      ? {
+          textLength: streamingText.length,
+          eventCount: streamingEvents.length,
+          events: streamingEvents,
+        }
+      : null,
   }
 
   return (
@@ -292,13 +307,14 @@ function PendingCommandBar({ isConnected }: { isConnected: boolean }) {
         )}
       </div>
       {pendingCommands.map((cmd) => (
-        <div key={cmd.id} className="rounded-lg border border-amber-900/50 bg-surface/40 px-3 py-2.5">
+        <div
+          key={cmd.id}
+          className="rounded-lg border border-amber-900/50 bg-surface/40 px-3 py-2.5"
+        >
           <pre className="text-sm text-fg overflow-x-auto whitespace-pre-wrap mb-1.5">
             <code>{cmd.command}</code>
           </pre>
-          {cmd.explanation && (
-            <p className="text-xs text-fg-muted mb-2">{cmd.explanation}</p>
-          )}
+          {cmd.explanation && <p className="text-xs text-fg-muted mb-2">{cmd.explanation}</p>}
           <div className="flex items-center gap-2">
             <button
               onClick={() => approveCommand(bridge, cmd.id)}
@@ -317,9 +333,7 @@ function PendingCommandBar({ isConnected }: { isConnected: boolean }) {
           </div>
         </div>
       ))}
-      {!isConnected && (
-        <span className="text-[11px] text-fg-faint">Reconnect to approve.</span>
-      )}
+      {!isConnected && <span className="text-[11px] text-fg-faint">Reconnect to approve.</span>}
     </div>
   )
 }
@@ -381,9 +395,7 @@ function Composer({
           </div>
           <div className="flex items-center gap-1.5">
             {messageQueue.length > 0 && (
-              <span className="text-[11px] text-fg-faint mr-0.5">
-                {messageQueue.length} queued
-              </span>
+              <span className="text-[11px] text-fg-faint mr-0.5">{messageQueue.length} queued</span>
             )}
             {isStreaming ? (
               <div className="flex items-center gap-1.5">
@@ -404,7 +416,16 @@ function Composer({
                   className="flex items-center gap-1 rounded-lg bg-surface-active px-3 py-1.5 text-xs font-medium text-fg-tertiary transition-colors hover:bg-surface-strong disabled:opacity-25 disabled:cursor-not-allowed"
                 >
                   Queue
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
                     <path d="M12 5v14" />
                     <path d="m5 12 7 7 7-7" />
                   </svg>
@@ -415,7 +436,16 @@ function Composer({
                   className="flex items-center gap-1.5 rounded-lg bg-surface-invert px-3 py-1.5 text-xs font-medium text-fg-invert transition-colors hover:bg-white disabled:opacity-25 disabled:cursor-not-allowed"
                 >
                   Send
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
                     <path d="M5 12h14" />
                     <path d="m12 5 7 7-7 7" />
                   </svg>
@@ -427,7 +457,16 @@ function Composer({
                 className="flex items-center gap-1.5 rounded-lg bg-surface-invert px-3.5 py-1.5 text-xs font-medium text-fg-invert transition-colors hover:bg-white disabled:opacity-25 disabled:cursor-not-allowed"
               >
                 Send
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
                   <path d="M5 12h14" />
                   <path d="m12 5 7 7-7 7" />
                 </svg>

--- a/packages/ui/src/components/chat/chat-view.tsx
+++ b/packages/ui/src/components/chat/chat-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   AssistantRuntimeProvider,
   ThreadPrimitive,
@@ -13,6 +13,7 @@ import { useBridge } from '../../hooks/use-bridge'
 import { useAssistantRuntime } from '../../hooks/use-assistant-runtime'
 import { MarkdownText } from './markdown-text'
 import { AI_PROVIDER_LABELS, getSupportedAIProviders } from '../../lib/ai'
+import { setNextSendMode } from '../../hooks/use-assistant-runtime'
 
 type ToolArtifact = {
   kind?: AIToolKind
@@ -38,6 +39,7 @@ interface ChatViewProps {
 
 export function ChatView({ serverId, isConnected, connectionStatus }: ChatViewProps) {
   const bridge = useBridge()
+  const [debugMode, setDebugMode] = useState(false)
   const {
     init,
     loadSessions,
@@ -47,9 +49,20 @@ export function ChatView({ serverId, isConnected, connectionStatus }: ChatViewPr
     sessions,
     draftConfigs,
   } = useChatStore()
-  const runtime = useAssistantRuntime(serverId)
+  const servers = useServerStore((s) => s.servers)
   const activeSession = activeSessionId ? sessions[activeSessionId] : null
-  const sessionForServer = activeSession?.serverId === serverId ? activeSession : null
+  // Use the session's serverIds (multi-server) or fall back to the single selected server
+  const sessionServerIds = activeSession?.serverIds ?? [serverId]
+  const isMultiServer = sessionServerIds.length > 1
+  const runtime = useAssistantRuntime(sessionServerIds)
+  const sessionForServer = activeSession?.serverIds.includes(serverId) ? activeSession : null
+  const serverNamesList = useMemo(
+    () =>
+      sessionServerIds
+        .map((id) => servers.find((s) => s.id === id)?.name ?? id)
+        .join(', '),
+    [sessionServerIds, servers],
+  )
   const selectedConfig: AISessionConfig | null = sessionForServer
     ? {
         provider: sessionForServer.provider,
@@ -73,10 +86,16 @@ export function ChatView({ serverId, isConnected, connectionStatus }: ChatViewPr
     <AssistantRuntimeProvider runtime={runtime}>
       <div className="flex-1 flex flex-col min-h-0">
         {!isConnected && (
-          <div className="border-b border-zinc-800 px-4 py-2 text-xs text-zinc-500">
+          <div className="border-b border-edge-subtle px-4 py-2 text-xs text-fg-faint">
             {connectionStatus === 'connecting'
               ? 'Connecting. Session history is available now, and chat input will unlock once the server is connected.'
               : 'Viewing session history. Reconnect to continue chatting or approve commands.'}
+          </div>
+        )}
+
+        {isMultiServer && (
+          <div className="border-b border-sky-900/50 bg-sky-950/30 px-4 py-2 text-xs text-sky-300">
+            Multi-server session: {serverNamesList}
           </div>
         )}
 
@@ -86,31 +105,50 @@ export function ChatView({ serverId, isConnected, connectionStatus }: ChatViewPr
           </div>
         ) : null}
 
-        <Thread serverId={serverId} isConnected={isConnected} />
+        <Thread serverId={serverId} isConnected={isConnected} isMultiServer={isMultiServer} debugMode={debugMode} setDebugMode={setDebugMode} />
       </div>
     </AssistantRuntimeProvider>
   )
 }
 
-function Thread({ serverId, isConnected }: { serverId: string; isConnected: boolean }) {
+function Thread({
+  serverId,
+  isConnected,
+  isMultiServer,
+  debugMode,
+  setDebugMode,
+}: {
+  serverId: string
+  isConnected: boolean
+  isMultiServer: boolean
+  debugMode: boolean
+  setDebugMode: (v: boolean) => void
+}) {
   return (
     <ThreadPrimitive.Root className="flex-1 flex flex-col min-h-0">
       <ThreadPrimitive.Viewport className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
         <ThreadPrimitive.Empty>
-          <div className="text-center text-zinc-600 py-12">
-            <p className="text-sm">Ask the AI to inspect, debug, or manage this server.</p>
+          <div className="text-center text-fg-dim py-12">
+            <p className="text-sm">
+              {isMultiServer
+                ? 'Ask the AI to work across your servers — compare configs, set up replication, and more.'
+                : 'Ask the AI to inspect, debug, or manage this server.'}
+            </p>
           </div>
         </ThreadPrimitive.Empty>
 
         <ThreadPrimitive.Messages
           components={{
-            UserMessage,
+            UserMessage: () => <UserMessage />,
             AssistantMessage: () => <AssistantMessage isConnected={isConnected} />,
           }}
         />
       </ThreadPrimitive.Viewport>
 
-      <Composer serverId={serverId} isConnected={isConnected} />
+      {debugMode && <SessionDebugPanel />}
+
+      <PendingCommandBar isConnected={isConnected} />
+      <Composer serverId={serverId} isConnected={isConnected} isMultiServer={isMultiServer} debugMode={debugMode} setDebugMode={setDebugMode} />
     </ThreadPrimitive.Root>
   )
 }
@@ -118,7 +156,7 @@ function Thread({ serverId, isConnected }: { serverId: string; isConnected: bool
 function UserMessage() {
   return (
     <MessagePrimitive.Root className="flex justify-end">
-      <div className="max-w-[80%] min-w-0 px-4 py-2.5 rounded-lg text-sm bg-zinc-800 text-zinc-100">
+      <div className="max-w-[80%] min-w-0 px-4 py-2.5 rounded-lg text-sm bg-surface-raised text-fg">
         <MessagePrimitive.Content components={{ Text: MarkdownText }} />
       </div>
     </MessagePrimitive.Root>
@@ -129,7 +167,7 @@ function AssistantMessage({ isConnected }: { isConnected: boolean }) {
   return (
     <MessagePrimitive.Root>
       <MessagePrimitive.If hasContent>
-        <div className="min-w-0 px-4 py-3 rounded-lg text-sm bg-zinc-900 border border-zinc-800 text-zinc-300 space-y-3">
+        <div className="min-w-0 px-4 py-3 rounded-lg text-sm bg-surface-alt border border-edge-subtle text-fg-tertiary space-y-3">
           <MessagePrimitive.Parts
             components={{
               Text: MarkdownText,
@@ -148,6 +186,38 @@ function AssistantMessage({ isConnected }: { isConnected: boolean }) {
   )
 }
 
+function SessionDebugPanel() {
+  const { activeSessionId, sessions, streamingText, streamingEvents, isStreaming, messageQueue } =
+    useChatStore()
+  const session = activeSessionId ? sessions[activeSessionId] : null
+
+  const debugData = {
+    activeSessionId,
+    isStreaming,
+    messageQueue,
+    session: session
+      ? {
+          id: session.id,
+          serverIds: session.serverIds,
+          provider: session.provider,
+          model: session.model,
+          yoloMode: session.yoloMode,
+          messageCount: session.messages.length,
+          messages: session.messages,
+        }
+      : null,
+    streaming: isStreaming ? { textLength: streamingText.length, eventCount: streamingEvents.length, events: streamingEvents } : null,
+  }
+
+  return (
+    <div className="border-t border-violet-900/50 bg-violet-950/20 max-h-64 overflow-y-auto">
+      <pre className="px-4 py-3 text-[10px] leading-4 text-violet-300/80 whitespace-pre-wrap font-mono">
+        {JSON.stringify(debugData, null, 2)}
+      </pre>
+    </div>
+  )
+}
+
 function AssistantMessagePending() {
   return (
     <div
@@ -155,53 +225,215 @@ function AssistantMessagePending() {
       role="status"
       aria-label="Assistant is thinking"
     >
-      <span className="h-1.5 w-1.5 rounded-full bg-zinc-500 animate-pulse" />
-      <span className="h-1.5 w-1.5 rounded-full bg-zinc-500 animate-pulse [animation-delay:150ms]" />
-      <span className="h-1.5 w-1.5 rounded-full bg-zinc-500 animate-pulse [animation-delay:300ms]" />
+      <span className="h-1.5 w-1.5 rounded-full bg-fg-faint animate-pulse" />
+      <span className="h-1.5 w-1.5 rounded-full bg-fg-faint animate-pulse [animation-delay:150ms]" />
+      <span className="h-1.5 w-1.5 rounded-full bg-fg-faint animate-pulse [animation-delay:300ms]" />
     </div>
   )
 }
 
-function Composer({ serverId, isConnected }: { serverId: string; isConnected: boolean }) {
+type PendingCommand = { id: string; command: string; explanation: string }
+
+function PendingCommandBar({ isConnected }: { isConnected: boolean }) {
+  const bridge = useBridge()
+  const { streamingEvents, isStreaming, approveCommand, rejectCommand } = useChatStore()
+  const barRef = useRef<HTMLDivElement>(null)
+
+  const pendingCommands = useMemo(() => {
+    if (!isStreaming) return []
+    const resolved = new Set<string>()
+    for (const e of streamingEvents) {
+      if (e.type === 'command_running' || e.type === 'command_done') {
+        resolved.add(e.id)
+      }
+    }
+    const pending: PendingCommand[] = []
+    for (const e of streamingEvents) {
+      if (e.type === 'command_proposal' && !resolved.has(e.id)) {
+        pending.push({ id: e.id, command: e.command, explanation: e.explanation })
+      }
+    }
+    return pending
+  }, [isStreaming, streamingEvents])
+
+  // Auto-scroll the bar into view when new commands arrive
+  const latestId = pendingCommands.at(-1)?.id
+  useEffect(() => {
+    if (latestId && barRef.current) {
+      barRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [latestId])
+
+  if (pendingCommands.length === 0) return null
+
+  const approveAll = () => {
+    for (const cmd of pendingCommands) approveCommand(bridge, cmd.id)
+  }
+
+  return (
+    <div
+      ref={barRef}
+      className="border-t border-amber-700/60 bg-gradient-to-b from-amber-950/50 to-amber-950/30 px-4 py-3 space-y-3"
+    >
+      <div className="flex items-center justify-between">
+        <div className="text-[11px] font-medium uppercase tracking-wide text-amber-400/80">
+          {pendingCommands.length === 1
+            ? 'Command awaiting approval'
+            : `${pendingCommands.length} commands awaiting approval`}
+        </div>
+        {pendingCommands.length > 1 && (
+          <button
+            onClick={approveAll}
+            disabled={!isConnected}
+            className="rounded-md bg-emerald-600 px-3 py-1 text-[11px] font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+          >
+            Approve all
+          </button>
+        )}
+      </div>
+      {pendingCommands.map((cmd) => (
+        <div key={cmd.id} className="rounded-lg border border-amber-900/50 bg-surface/40 px-3 py-2.5">
+          <pre className="text-sm text-fg overflow-x-auto whitespace-pre-wrap mb-1.5">
+            <code>{cmd.command}</code>
+          </pre>
+          {cmd.explanation && (
+            <p className="text-xs text-fg-muted mb-2">{cmd.explanation}</p>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => approveCommand(bridge, cmd.id)}
+              disabled={!isConnected}
+              className="rounded-md bg-emerald-600 px-4 py-1.5 text-xs font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+            >
+              Approve
+            </button>
+            <button
+              onClick={() => rejectCommand(bridge, cmd.id)}
+              disabled={!isConnected}
+              className="rounded-lg bg-surface-active px-3 py-1.5 text-xs font-medium text-fg-secondary hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      ))}
+      {!isConnected && (
+        <span className="text-[11px] text-fg-faint">Reconnect to approve.</span>
+      )}
+    </div>
+  )
+}
+
+function Composer({
+  serverId,
+  isConnected,
+  isMultiServer,
+  debugMode,
+  setDebugMode,
+}: {
+  serverId: string
+  isConnected: boolean
+  isMultiServer?: boolean
+  debugMode: boolean
+  setDebugMode: (v: boolean) => void
+}) {
+  const bridge = useBridge()
+  const { isStreaming, killSession, messageQueue } = useChatStore()
   const serverColor = useServerStore((s) => s.servers.find((srv) => srv.id === serverId)?.color)
   const tintStyle = serverColor
     ? { backgroundImage: `linear-gradient(${serverColor}1f, ${serverColor}1f)` }
     : undefined
 
   return (
-    <ComposerPrimitive.Root className="border-t border-zinc-800/60 bg-zinc-900/50 px-4 py-3">
+    <ComposerPrimitive.Root className="border-t border-edge-subtle/60 bg-surface-alt/50 px-4 py-3">
       <div
-        className="rounded-xl border border-zinc-700/50 bg-zinc-800/60 shadow-lg shadow-black/20 focus-within:border-zinc-600/70 transition-colors"
+        className="rounded-xl border border-edge/50 bg-surface-raised/60 shadow-lg shadow-black/20 focus-within:border-edge-strong/70 transition-colors"
         style={tintStyle}
       >
         <ComposerPrimitive.Input
           autoFocus={isConnected}
           disabled={!isConnected}
-          placeholder={isConnected ? 'Ask about this server...' : 'Reconnect to continue chatting'}
+          placeholder={
+            !isConnected
+              ? 'Reconnect to continue chatting'
+              : isMultiServer
+                ? 'Ask about your servers...'
+                : 'Ask about this server...'
+          }
           rows={1}
-          className="w-full bg-transparent px-4 pt-3 pb-2 text-sm text-zinc-100 placeholder-zinc-500 resize-none focus:outline-none disabled:opacity-50"
+          className="w-full bg-transparent px-4 pt-3 pb-2 text-sm text-fg placeholder-fg-faint resize-none focus:outline-none disabled:opacity-50"
         />
-        <div className="flex items-center justify-between gap-2 px-3 pb-2.5">
-          <SessionConfigControls serverId={serverId} />
-          <ComposerPrimitive.Send
-            disabled={!isConnected}
-            className="flex items-center gap-1.5 rounded-lg bg-zinc-100 px-3.5 py-1.5 text-xs font-medium text-zinc-900 transition-colors hover:bg-white disabled:opacity-25 disabled:cursor-not-allowed"
-          >
-            Send
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+        <div className="flex flex-wrap items-center justify-between gap-2 px-3 pb-2.5">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <SessionConfigControls serverId={serverId} />
+            <button
+              type="button"
+              onClick={() => setDebugMode(!debugMode)}
+              title="Toggle debug mode — show raw message data"
+              className={`rounded-md px-2 py-1.5 text-[11px] font-mono transition-colors ${
+                debugMode
+                  ? 'bg-violet-600/30 text-violet-300 border border-violet-500/50'
+                  : 'bg-surface-active/40 text-fg-faint hover:bg-surface-active/60 hover:text-fg-muted'
+              }`}
             >
-              <path d="M5 12h14" />
-              <path d="m12 5 7 7-7 7" />
-            </svg>
-          </ComposerPrimitive.Send>
+              {'{}'}
+            </button>
+          </div>
+          <div className="flex items-center gap-1.5">
+            {messageQueue.length > 0 && (
+              <span className="text-[11px] text-fg-faint mr-0.5">
+                {messageQueue.length} queued
+              </span>
+            )}
+            {isStreaming ? (
+              <div className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => killSession(bridge)}
+                  title="Stop"
+                  className="flex items-center justify-center rounded-lg bg-red-500/90 px-2.5 py-1.5 text-white transition-colors hover:bg-red-400"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                    <rect x="6" y="6" width="12" height="12" rx="2" />
+                  </svg>
+                </button>
+                <ComposerPrimitive.Send
+                  disabled={!isConnected}
+                  onMouseDown={() => setNextSendMode('queue')}
+                  title="Queue this message — send after the current response finishes"
+                  className="flex items-center gap-1 rounded-lg bg-surface-active px-3 py-1.5 text-xs font-medium text-fg-tertiary transition-colors hover:bg-surface-strong disabled:opacity-25 disabled:cursor-not-allowed"
+                >
+                  Queue
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M12 5v14" />
+                    <path d="m5 12 7 7 7-7" />
+                  </svg>
+                </ComposerPrimitive.Send>
+                <ComposerPrimitive.Send
+                  disabled={!isConnected}
+                  title="Interrupt the current response and send this message now"
+                  className="flex items-center gap-1.5 rounded-lg bg-surface-invert px-3 py-1.5 text-xs font-medium text-fg-invert transition-colors hover:bg-white disabled:opacity-25 disabled:cursor-not-allowed"
+                >
+                  Send
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M5 12h14" />
+                    <path d="m12 5 7 7-7 7" />
+                  </svg>
+                </ComposerPrimitive.Send>
+              </div>
+            ) : (
+              <ComposerPrimitive.Send
+                disabled={!isConnected}
+                className="flex items-center gap-1.5 rounded-lg bg-surface-invert px-3.5 py-1.5 text-xs font-medium text-fg-invert transition-colors hover:bg-white disabled:opacity-25 disabled:cursor-not-allowed"
+              >
+                Send
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 12h14" />
+                  <path d="m12 5 7 7-7 7" />
+                </svg>
+              </ComposerPrimitive.Send>
+            )}
+          </div>
         </div>
       </div>
     </ComposerPrimitive.Root>
@@ -224,7 +456,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
     loadModels,
   } = useChatStore()
   const activeSession = activeSessionId ? sessions[activeSessionId] : null
-  const sessionForServer = activeSession?.serverId === serverId ? activeSession : null
+  const sessionForServer = activeSession?.serverIds.includes(serverId) ? activeSession : null
 
   const config: AISessionConfig | null = sessionForServer
     ? {
@@ -254,7 +486,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5">
+    <div className="flex flex-wrap items-center gap-1.5 min-w-0">
       <select
         value={config.provider}
         disabled={selectionDisabled}
@@ -268,7 +500,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
           applyConfig(nextConfig)
           loadModels(bridge, provider).catch(() => {})
         }}
-        className="rounded-md border-none bg-zinc-700/40 px-2.5 py-1.5 text-[11px] text-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-500 disabled:opacity-50 cursor-pointer hover:bg-zinc-700/60 transition-colors appearance-none"
+        className="min-w-0 rounded-md border-none bg-surface-active/40 px-2.5 py-1.5 text-[11px] text-fg-muted focus:outline-none focus:ring-1 focus:ring-edge-strong disabled:opacity-50 cursor-pointer hover:bg-surface-active/60 transition-colors appearance-none"
       >
         {providerOptions.map((provider) => (
           <option key={provider} value={provider}>
@@ -277,7 +509,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
         ))}
       </select>
 
-      <span className="text-zinc-600 text-[10px]">/</span>
+      <span className="text-fg-dim text-[10px]">/</span>
 
       <select
         value={config.model ?? ''}
@@ -289,7 +521,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
             yoloMode: config.yoloMode,
           })
         }
-        className="max-w-44 rounded-md border-none bg-zinc-700/40 px-2.5 py-1.5 text-[11px] text-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-500 disabled:opacity-50 cursor-pointer hover:bg-zinc-700/60 transition-colors appearance-none"
+        className="min-w-0 max-w-44 rounded-md border-none bg-surface-active/40 px-2.5 py-1.5 text-[11px] text-fg-muted focus:outline-none focus:ring-1 focus:ring-edge-strong disabled:opacity-50 cursor-pointer hover:bg-surface-active/60 transition-colors appearance-none"
       >
         <option value="">Default model</option>
         {selectedModelMissing && config.model ? (
@@ -316,7 +548,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
         className={`rounded-md px-2.5 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em] transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
           config.yoloMode
             ? 'border border-red-500/80 bg-red-600 text-white shadow-sm shadow-red-950/60 hover:bg-red-500'
-            : 'border border-zinc-700/70 bg-zinc-800/50 text-zinc-500 hover:bg-zinc-700/70 hover:text-zinc-300'
+            : 'border border-edge/70 bg-surface-raised/50 text-fg-faint hover:bg-surface-active/70 hover:text-fg-tertiary'
         }`}
       >
         YOLO
@@ -327,7 +559,7 @@ function SessionConfigControls({ serverId }: { serverId: string }) {
           !
         </span>
       ) : modelState === 'loading' ? (
-        <span className="text-[10px] text-zinc-500 ml-1">Loading...</span>
+        <span className="text-[10px] text-fg-faint ml-1">Loading...</span>
       ) : null}
     </div>
   )
@@ -410,14 +642,14 @@ function ToolCallPart({
         <details className="group">
           <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 marker:content-none">
             <div className="flex min-w-0 items-center gap-2">
-              <span className="text-xs text-zinc-500 transition-transform group-open:rotate-90">
+              <span className="text-xs text-fg-faint transition-transform group-open:rotate-90">
                 &gt;
               </span>
               <div className="min-w-0">
                 <div className="text-xs font-medium uppercase tracking-wide text-amber-300">
                   {title}
                 </div>
-                <div className="text-[11px] text-zinc-500 truncate">{toolName}</div>
+                <div className="text-[11px] text-fg-faint truncate">{toolName}</div>
               </div>
             </div>
             {showStatus ? (
@@ -431,17 +663,17 @@ function ToolCallPart({
 
           <div className="space-y-3 border-t border-amber-900/70 px-3 py-3">
             {command ? (
-              <pre className="overflow-x-auto rounded bg-zinc-950 px-3 py-2 text-xs text-zinc-100 whitespace-pre-wrap">
+              <pre className="overflow-x-auto rounded bg-surface px-3 py-2 text-xs text-fg whitespace-pre-wrap">
                 <code>{command}</code>
               </pre>
             ) : detailText ? (
-              <pre className="overflow-x-auto rounded bg-zinc-950 px-3 py-2 text-xs text-zinc-100 whitespace-pre-wrap">
+              <pre className="overflow-x-auto rounded bg-surface px-3 py-2 text-xs text-fg whitespace-pre-wrap">
                 <code>{detailText}</code>
               </pre>
             ) : null}
 
             {meta.explanation ? (
-              <p className="text-xs leading-5 text-zinc-400">{meta.explanation}</p>
+              <p className="text-xs leading-5 text-fg-muted">{meta.explanation}</p>
             ) : null}
 
             {meta.error ? <p className="text-xs leading-5 text-rose-300">{meta.error}</p> : null}
@@ -458,12 +690,12 @@ function ToolCallPart({
                 <button
                   onClick={() => rejectCommand(bridge, toolCallId)}
                   disabled={!isConnected}
-                  className="rounded bg-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-200 hover:bg-zinc-600 disabled:cursor-not-allowed disabled:opacity-40"
+                  className="rounded bg-surface-active px-3 py-1.5 text-xs font-medium text-fg-secondary hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   Reject
                 </button>
                 {!isConnected ? (
-                  <span className="text-[11px] text-zinc-500">
+                  <span className="text-[11px] text-fg-faint">
                     Reconnect to approve this command.
                   </span>
                 ) : null}
@@ -471,7 +703,7 @@ function ToolCallPart({
             ) : null}
 
             {showExitCode ? (
-              <div className="text-xs text-zinc-400">
+              <div className="text-xs text-fg-muted">
                 Exit code:{' '}
                 <span className={exitCode === 0 ? 'text-emerald-300' : 'text-rose-300'}>
                   {exitCode}
@@ -482,25 +714,25 @@ function ToolCallPart({
             {stdout ? <OutputBlock label="stdout" tone="text-emerald-200" value={stdout} /> : null}
 
             {meta.stdoutTruncated ? (
-              <p className="text-[11px] text-zinc-500">stdout was truncated for display.</p>
+              <p className="text-[11px] text-fg-faint">stdout was truncated for display.</p>
             ) : null}
 
             {stderr ? <OutputBlock label="stderr" tone="text-rose-200" value={stderr} /> : null}
 
             {meta.stderrTruncated ? (
-              <p className="text-[11px] text-zinc-500">stderr was truncated for display.</p>
+              <p className="text-[11px] text-fg-faint">stderr was truncated for display.</p>
             ) : null}
 
             {showGenericResult ? (
               <OutputBlock
                 label={isError ? 'error' : 'result'}
-                tone={isError ? 'text-rose-200' : 'text-zinc-200'}
+                tone={isError ? 'text-rose-200' : 'text-fg-secondary'}
                 value={formatValue(result)}
               />
             ) : null}
 
             {status === 'rejected' ? (
-              <p className="text-xs text-zinc-400">Command rejected.</p>
+              <p className="text-xs text-fg-muted">Command rejected.</p>
             ) : null}
           </div>
         </details>
@@ -510,7 +742,7 @@ function ToolCallPart({
             <div className="text-xs font-medium uppercase tracking-wide text-amber-300">
               {title}
             </div>
-            <div className="text-[11px] text-zinc-500 truncate">{toolName}</div>
+            <div className="text-[11px] text-fg-faint truncate">{toolName}</div>
           </div>
           {showStatus ? (
             <span
@@ -528,9 +760,9 @@ function ToolCallPart({
 function OutputBlock({ label, tone, value }: { label: string; tone: string; value: string }) {
   return (
     <div className="space-y-1">
-      <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">{label}</div>
+      <div className="text-[11px] font-medium uppercase tracking-wide text-fg-faint">{label}</div>
       <pre
-        className={`overflow-x-auto rounded bg-zinc-950 px-3 py-2 text-xs whitespace-pre-wrap ${tone}`}
+        className={`overflow-x-auto rounded bg-surface px-3 py-2 text-xs whitespace-pre-wrap ${tone}`}
       >
         <code>{value}</code>
       </pre>
@@ -570,7 +802,7 @@ function statusTone(status: ToolArtifact['status']): string {
     case 'error':
       return 'bg-rose-950 text-rose-300 border border-rose-900/70'
     case 'rejected':
-      return 'bg-zinc-800 text-zinc-300 border border-zinc-700'
+      return 'bg-surface-raised text-fg-tertiary border border-edge'
     case 'pending':
     default:
       return 'bg-amber-950 text-amber-300 border border-amber-900/70'

--- a/packages/ui/src/components/chat/markdown-text.tsx
+++ b/packages/ui/src/components/chat/markdown-text.tsx
@@ -1,6 +1,8 @@
 import { MarkdownTextPrimitive } from '@assistant-ui/react-markdown'
 import remarkGfm from 'remark-gfm'
 
+const REMARK_PLUGINS = [remarkGfm]
+
 export function MarkdownText() {
-  return <MarkdownTextPrimitive className="aui-md-root" remarkPlugins={[remarkGfm]} smooth />
+  return <MarkdownTextPrimitive className="aui-md-root" remarkPlugins={REMARK_PLUGINS} smooth />
 }

--- a/packages/ui/src/components/chat/message-list.tsx
+++ b/packages/ui/src/components/chat/message-list.tsx
@@ -17,7 +17,7 @@ export function MessageList({ messages, streamingText, isStreaming }: MessageLis
   return (
     <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
       {messages.length === 0 && !isStreaming && (
-        <div className="text-center text-zinc-600 py-12">
+        <div className="text-center text-fg-dim py-12">
           <p className="text-sm">Ask the AI to inspect, debug, or manage this server.</p>
         </div>
       )}
@@ -30,8 +30,8 @@ export function MessageList({ messages, streamingText, isStreaming }: MessageLis
           <div
             className={`max-w-[80%] min-w-0 px-4 py-2.5 rounded-lg text-sm whitespace-pre-wrap ${
               msg.role === 'user'
-                ? 'bg-zinc-800 text-zinc-100'
-                : 'bg-zinc-900 border border-zinc-800 text-zinc-300'
+                ? 'bg-surface-raised text-fg'
+                : 'bg-surface-alt border border-edge-subtle text-fg-tertiary'
             }`}
           >
             {msg.content}
@@ -41,7 +41,7 @@ export function MessageList({ messages, streamingText, isStreaming }: MessageLis
 
       {isStreaming && streamingText && (
         <div className="flex justify-start">
-          <div className="max-w-[80%] px-4 py-2.5 rounded-lg text-sm bg-zinc-900 border border-zinc-800 text-zinc-300 whitespace-pre-wrap">
+          <div className="max-w-[80%] px-4 py-2.5 rounded-lg text-sm bg-surface-alt border border-edge-subtle text-fg-tertiary whitespace-pre-wrap">
             {streamingText}
             <span className="inline-block w-1.5 h-4 bg-zinc-400 ml-0.5 animate-pulse" />
           </div>

--- a/packages/ui/src/components/layout/main-panel.tsx
+++ b/packages/ui/src/components/layout/main-panel.tsx
@@ -58,7 +58,7 @@ export function MainPanel() {
   // Settings view — full panel takeover
   if (activeView === 'global') {
     return (
-      <div className="flex-1 flex flex-col bg-zinc-950 min-w-0">
+      <div className="flex-1 flex flex-col bg-surface min-w-0">
         <SettingsView onClose={closeSettingsView} />
       </div>
     )
@@ -70,17 +70,17 @@ export function MainPanel() {
       : null
     if (!editingServer) {
       return (
-        <div className="flex-1 flex flex-col bg-zinc-950 min-w-0">
-          <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-zinc-100">Server Settings</h2>
+        <div className="flex-1 flex flex-col bg-surface min-w-0">
+          <div className="px-6 py-4 border-b border-edge-subtle flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-fg">Server Settings</h2>
             <button
               onClick={closeSettingsView}
-              className="text-zinc-400 hover:text-zinc-100 text-sm px-3 py-1.5 rounded-md hover:bg-zinc-800 transition-colors"
+              className="text-fg-muted hover:text-fg text-sm px-3 py-1.5 rounded-md hover:bg-surface-raised transition-colors"
             >
               Close
             </button>
           </div>
-          <div className="flex-1 flex items-center justify-center text-sm text-zinc-500">
+          <div className="flex-1 flex items-center justify-center text-sm text-fg-faint">
             Server not found.
           </div>
         </div>
@@ -88,7 +88,7 @@ export function MainPanel() {
     }
 
     return (
-      <div className="flex-1 flex flex-col bg-zinc-950 min-w-0">
+      <div className="flex-1 flex flex-col bg-surface min-w-0">
         <ServerSettingsView server={editingServer} />
       </div>
     )
@@ -96,8 +96,8 @@ export function MainPanel() {
 
   if (!activeServerId) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-zinc-950">
-        <div className="text-center text-zinc-500">
+      <div className="flex-1 flex items-center justify-center bg-surface">
+        <div className="text-center text-fg-faint">
           <p className="text-lg mb-1">No server selected</p>
           <p className="text-sm">Select or add a server to get started</p>
         </div>
@@ -112,15 +112,15 @@ export function MainPanel() {
   if (!server) return null
 
   return (
-    <div className="flex-1 flex flex-col bg-zinc-950 min-w-0">
+    <div className="flex-1 flex flex-col bg-surface min-w-0">
       {/* Server header */}
-      <div className="px-4 py-3 border-b border-zinc-800 flex items-center gap-3">
+      <div className="px-4 py-3 border-b border-edge-subtle flex items-center gap-3">
         {/* Sidebar toggle */}
         {sidebarCollapsed && (
           <button
             onClick={toggleSidebar}
             title="Show sidebar"
-            className="text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 rounded-md p-1 transition-colors"
+            className="text-fg-faint hover:text-fg-tertiary hover:bg-surface-raised rounded-md p-1 transition-colors"
           >
             <svg
               className="w-4 h-4"
@@ -146,12 +146,12 @@ export function MainPanel() {
                 ? 'bg-yellow-400'
                 : connection?.status === 'error'
                   ? 'bg-red-400'
-                  : 'bg-zinc-600'
+                  : 'bg-surface-strong'
           }`}
         />
         <div>
-          <span className="text-sm font-medium text-zinc-100">{server.name}</span>
-          <span className="text-xs text-zinc-500 ml-2">
+          <span className="text-sm font-medium text-fg">{server.name}</span>
+          <span className="text-xs text-fg-faint ml-2">
             {anonymousMode ? maskUsername(server.username) : server.username}@
             {anonymousMode ? maskHost(server.host) : server.host}:
             {anonymousMode ? maskPort(server.port) : server.port}
@@ -246,7 +246,7 @@ export function MainPanel() {
         {panelLayout === 'split' && (
           <div
             onMouseDown={handleMouseDown}
-            className="w-1 flex-shrink-0 bg-zinc-800 hover:bg-zinc-600 cursor-col-resize transition-colors relative group"
+            className="w-1 flex-shrink-0 bg-surface-raised hover:bg-surface-strong cursor-col-resize transition-colors relative group"
           >
             <div className="absolute inset-y-0 -left-1 -right-1" />
           </div>
@@ -282,7 +282,7 @@ function PanelToggleButton({
       onClick={onClick}
       title={title}
       className={`p-1.5 rounded transition-colors ${
-        active ? 'bg-zinc-700 text-zinc-200' : 'text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800'
+        active ? 'bg-surface-active text-fg-secondary' : 'text-fg-faint hover:text-fg-tertiary hover:bg-surface-raised'
       }`}
     >
       {children}

--- a/packages/ui/src/components/layout/main-panel.tsx
+++ b/packages/ui/src/components/layout/main-panel.tsx
@@ -282,7 +282,9 @@ function PanelToggleButton({
       onClick={onClick}
       title={title}
       className={`p-1.5 rounded transition-colors ${
-        active ? 'bg-surface-active text-fg-secondary' : 'text-fg-faint hover:text-fg-tertiary hover:bg-surface-raised'
+        active
+          ? 'bg-surface-active text-fg-secondary'
+          : 'text-fg-faint hover:text-fg-tertiary hover:bg-surface-raised'
       }`}
     >
       {children}

--- a/packages/ui/src/components/layout/sidebar.tsx
+++ b/packages/ui/src/components/layout/sidebar.tsx
@@ -54,7 +54,7 @@ export function Sidebar() {
   return (
     <div className="flex h-full">
       {/* Activity bar — thin icon strip */}
-      <div className="w-12 bg-zinc-950 border-r border-zinc-800 flex flex-col items-center py-3 gap-1 flex-shrink-0">
+      <div className="w-12 bg-surface border-r border-edge-subtle flex flex-col items-center py-3 gap-1 flex-shrink-0">
         <ActivityBarButton
           active={activePanel === 'servers'}
           onClick={() => setActivePanel('servers')}
@@ -134,13 +134,13 @@ export function Sidebar() {
       </div>
 
       {/* Panel content */}
-      <div className="w-56 bg-zinc-900 border-r border-zinc-800 flex flex-col h-full">
-        <div className="p-4 border-b border-zinc-800 flex items-center justify-between">
-          <h1 className="text-sm font-bold text-zinc-100 tracking-wide uppercase">Paulus</h1>
+      <div className="w-56 bg-surface-alt border-r border-edge-subtle flex flex-col h-full">
+        <div className="p-4 border-b border-edge-subtle flex items-center justify-between">
+          <h1 className="text-sm font-bold text-fg tracking-wide uppercase">Paulus</h1>
           <button
             onClick={toggleSidebar}
             title="Collapse sidebar"
-            className="text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 rounded-md p-1 transition-colors"
+            className="text-fg-faint hover:text-fg-tertiary hover:bg-surface-raised rounded-md p-1 transition-colors"
           >
             <svg
               className="w-4 h-4"
@@ -163,7 +163,7 @@ export function Sidebar() {
             {activePanel === 'servers' ? (
               <>
                 <div className="flex items-center justify-between px-2 py-1">
-                  <span className="text-xs font-medium text-zinc-500 uppercase">Servers</span>
+                  <span className="text-xs font-medium text-fg-faint uppercase">Servers</span>
                   <AddMenu
                     onAddServer={() => setShowAddForm(true)}
                     onAddCategory={() => setShowAddCategoryForm(true)}
@@ -197,7 +197,7 @@ export function Sidebar() {
           </div>
         </div>
 
-        <div className="border-t border-zinc-800" />
+        <div className="border-t border-edge-subtle" />
       </div>
 
       {showAddForm && <ServerForm onClose={() => setShowAddForm(false)} />}
@@ -235,8 +235,8 @@ function ActivityBarButton({
       title={label}
       className={`w-10 h-10 flex items-center justify-center rounded-lg transition-colors ${
         active
-          ? 'bg-zinc-800 text-zinc-100'
-          : 'text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800/50'
+          ? 'bg-surface-raised text-fg'
+          : 'text-fg-faint hover:text-fg-tertiary hover:bg-surface-raised/50'
       }`}
     >
       {children}
@@ -279,24 +279,24 @@ function AddMenu({
         onClick={() => setOpen((prev) => !prev)}
         title="Add"
         aria-label="Add server or category"
-        className="flex h-6 w-6 items-center justify-center rounded text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+        className="flex h-6 w-6 items-center justify-center rounded text-fg-muted hover:bg-surface-raised hover:text-fg"
       >
         <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
           <path d="M10 4a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 10 4Z" />
         </svg>
       </button>
       {open && (
-        <div className="absolute right-0 top-full z-30 mt-1 min-w-44 overflow-hidden rounded-md border border-zinc-700 bg-zinc-900 py-1 shadow-2xl">
+        <div className="absolute right-0 top-full z-30 mt-1 min-w-44 overflow-hidden rounded-md border border-edge bg-surface-alt py-1 shadow-2xl">
           <button
             type="button"
             onClick={() => {
               setOpen(false)
               onAddServer()
             }}
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-fg-secondary hover:bg-surface-raised"
           >
             <svg
-              className="h-4 w-4 text-zinc-500"
+              className="h-4 w-4 text-fg-faint"
               fill="none"
               viewBox="0 0 24 24"
               strokeWidth={1.5}
@@ -316,10 +316,10 @@ function AddMenu({
               setOpen(false)
               onAddCategory()
             }}
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-fg-secondary hover:bg-surface-raised"
           >
             <svg
-              className="h-4 w-4 text-zinc-500"
+              className="h-4 w-4 text-fg-faint"
               fill="none"
               viewBox="0 0 24 24"
               strokeWidth={1.5}

--- a/packages/ui/src/components/servers/category-form.tsx
+++ b/packages/ui/src/components/servers/category-form.tsx
@@ -40,12 +40,12 @@ export function CategoryForm({ onClose }: CategoryFormProps) {
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
       <form
         onSubmit={handleSubmit}
-        className="bg-zinc-900 border border-zinc-700 rounded-lg p-6 w-[24rem] space-y-4"
+        className="bg-surface-alt border border-edge rounded-lg p-6 w-[24rem] space-y-4"
       >
-        <h2 className="text-lg font-medium text-zinc-100">Add Category</h2>
+        <h2 className="text-lg font-medium text-fg">Add Category</h2>
 
         <div>
-          <label className="block text-xs text-zinc-400 mb-1">Name</label>
+          <label className="block text-xs text-fg-muted mb-1">Name</label>
           <input
             type="text"
             required
@@ -55,13 +55,13 @@ export function CategoryForm({ onClose }: CategoryFormProps) {
               setName(e.target.value)
               if (error) setError(null)
             }}
-            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+            className="w-full bg-surface-raised border border-edge rounded px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
             placeholder="Production"
           />
           {error && <p className="text-xs text-red-300 mt-1.5">{error}</p>}
         </div>
 
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-fg-faint">
           Categories group servers in the sidebar. You can also assign a category when adding or
           editing a server.
         </p>
@@ -70,14 +70,14 @@ export function CategoryForm({ onClose }: CategoryFormProps) {
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200"
+            className="px-4 py-2 text-sm text-fg-muted hover:text-fg-secondary"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 text-sm bg-zinc-100 text-zinc-900 rounded hover:bg-zinc-200 disabled:opacity-50"
+            className="px-4 py-2 text-sm bg-surface-invert text-fg-invert rounded hover:bg-surface-invert-hover disabled:opacity-50"
           >
             {saving ? 'Adding...' : 'Add Category'}
           </button>

--- a/packages/ui/src/components/servers/category-picker.tsx
+++ b/packages/ui/src/components/servers/category-picker.tsx
@@ -67,11 +67,11 @@ export function CategoryPicker({ value, categories, onChange }: CategoryPickerPr
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
-        className="flex w-full items-center justify-between gap-2 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 hover:border-zinc-600 focus:border-zinc-500 focus:outline-none"
+        className="flex w-full items-center justify-between gap-2 rounded-md border border-edge bg-surface-raised px-3 py-2 text-sm text-fg hover:border-edge-strong focus:border-edge-strong focus:outline-none"
       >
         <span className="truncate">{selected}</span>
         <svg
-          className={`h-4 w-4 flex-shrink-0 text-zinc-500 transition-transform ${
+          className={`h-4 w-4 flex-shrink-0 text-fg-faint transition-transform ${
             open ? 'rotate-180' : ''
           }`}
           viewBox="0 0 20 20"
@@ -86,7 +86,7 @@ export function CategoryPicker({ value, categories, onChange }: CategoryPickerPr
       </button>
 
       {open && (
-        <div className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-md border border-zinc-700 bg-zinc-900 shadow-2xl">
+        <div className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-md border border-edge bg-surface-alt shadow-2xl">
           <ul className="max-h-56 overflow-y-auto py-1">
             {allCategories.map((category) => {
               const isSelected = category === selected
@@ -100,14 +100,14 @@ export function CategoryPicker({ value, categories, onChange }: CategoryPickerPr
                     }}
                     className={`flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm ${
                       isSelected
-                        ? 'bg-zinc-800 text-zinc-100'
-                        : 'text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100'
+                        ? 'bg-surface-raised text-fg'
+                        : 'text-fg-tertiary hover:bg-surface-raised hover:text-fg'
                     }`}
                   >
                     <span className="truncate">{category}</span>
                     {isSelected && (
                       <svg
-                        className="h-4 w-4 text-zinc-400"
+                        className="h-4 w-4 text-fg-muted"
                         viewBox="0 0 20 20"
                         fill="currentColor"
                       >
@@ -124,7 +124,7 @@ export function CategoryPicker({ value, categories, onChange }: CategoryPickerPr
             })}
           </ul>
 
-          <div className="border-t border-zinc-800 bg-zinc-950/40 p-1.5">
+          <div className="border-t border-edge-subtle bg-surface/40 p-1.5">
             {creating ? (
               <div className="flex items-center gap-1.5">
                 <input
@@ -138,12 +138,12 @@ export function CategoryPicker({ value, categories, onChange }: CategoryPickerPr
                     }
                   }}
                   placeholder="New category name"
-                  className="flex-1 rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-sm text-zinc-100 focus:border-zinc-500 focus:outline-none"
+                  className="flex-1 rounded border border-edge bg-surface-alt px-2 py-1 text-sm text-fg focus:border-edge-strong focus:outline-none"
                 />
                 <button
                   type="button"
                   onClick={commitDraft}
-                  className="rounded bg-zinc-100 px-2 py-1 text-xs font-medium text-zinc-900 hover:bg-zinc-200"
+                  className="rounded bg-surface-invert px-2 py-1 text-xs font-medium text-fg-invert hover:bg-surface-invert-hover"
                 >
                   Add
                 </button>
@@ -152,7 +152,7 @@ export function CategoryPicker({ value, categories, onChange }: CategoryPickerPr
               <button
                 type="button"
                 onClick={() => setCreating(true)}
-                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-fg-tertiary hover:bg-surface-raised hover:text-fg"
               >
                 <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                   <path d="M10 4a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 10 4Z" />

--- a/packages/ui/src/components/servers/password-prompt.tsx
+++ b/packages/ui/src/components/servers/password-prompt.tsx
@@ -21,11 +21,11 @@ export function PasswordPrompt({ serverName, onSubmit, onCancel }: PasswordPromp
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
       <form
         onSubmit={handleSubmit}
-        className="bg-zinc-900 border border-zinc-700 rounded-lg p-6 w-80 space-y-4"
+        className="bg-surface-alt border border-edge rounded-lg p-6 w-80 space-y-4"
       >
-        <h2 className="text-lg font-medium text-zinc-100">Enter Password</h2>
-        <p className="text-sm text-zinc-400">
-          Password required for <span className="text-zinc-200">{serverName}</span>
+        <h2 className="text-lg font-medium text-fg">Enter Password</h2>
+        <p className="text-sm text-fg-muted">
+          Password required for <span className="text-fg-secondary">{serverName}</span>
         </p>
 
         <div>
@@ -35,7 +35,7 @@ export function PasswordPrompt({ serverName, onSubmit, onCancel }: PasswordPromp
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+            className="w-full bg-surface-raised border border-edge rounded px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
             placeholder="SSH password"
           />
         </div>
@@ -45,22 +45,22 @@ export function PasswordPrompt({ serverName, onSubmit, onCancel }: PasswordPromp
             type="checkbox"
             checked={save}
             onChange={(e) => setSave(e.target.checked)}
-            className="rounded border-zinc-600 bg-zinc-800"
+            className="rounded border-edge-strong bg-surface-raised"
           />
-          <span className="text-sm text-zinc-300">Save to keychain</span>
+          <span className="text-sm text-fg-tertiary">Save to keychain</span>
         </label>
 
         <div className="flex justify-end gap-2 pt-2">
           <button
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200"
+            className="px-4 py-2 text-sm text-fg-muted hover:text-fg-secondary"
           >
             Cancel
           </button>
           <button
             type="submit"
-            className="px-4 py-2 text-sm bg-zinc-100 text-zinc-900 rounded hover:bg-zinc-200"
+            className="px-4 py-2 text-sm bg-surface-invert text-fg-invert rounded hover:bg-surface-invert-hover"
           >
             Connect
           </button>

--- a/packages/ui/src/components/servers/server-color-picker.tsx
+++ b/packages/ui/src/components/servers/server-color-picker.tsx
@@ -13,8 +13,8 @@ export function ServerColorPicker({ value, onChange }: ServerColorPickerProps) {
         onClick={() => onChange(undefined)}
         aria-label="No color"
         aria-pressed={!value}
-        className={`h-6 w-6 rounded-full border flex items-center justify-center text-zinc-500 hover:text-zinc-300 ${
-          !value ? 'border-zinc-300' : 'border-zinc-700'
+        className={`h-6 w-6 rounded-full border flex items-center justify-center text-fg-faint hover:text-fg-tertiary ${
+          !value ? 'border-zinc-300' : 'border-edge'
         }`}
       >
         <svg

--- a/packages/ui/src/components/servers/server-form.tsx
+++ b/packages/ui/src/components/servers/server-form.tsx
@@ -254,7 +254,9 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
             disabled={!autoConnectAvailable}
             className="rounded border-edge-strong bg-surface-raised"
           />
-          <span className={`text-sm ${autoConnectAvailable ? 'text-fg-tertiary' : 'text-fg-faint'}`}>
+          <span
+            className={`text-sm ${autoConnectAvailable ? 'text-fg-tertiary' : 'text-fg-faint'}`}
+          >
             Auto-connect on launch
           </span>
         </label>

--- a/packages/ui/src/components/servers/server-form.tsx
+++ b/packages/ui/src/components/servers/server-form.tsx
@@ -100,26 +100,26 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
       <form
         onSubmit={handleSubmit}
-        className="bg-zinc-900 border border-zinc-700 rounded-lg p-6 w-[28rem] space-y-4"
+        className="bg-surface-alt border border-edge rounded-lg p-6 w-[28rem] space-y-4"
       >
-        <h2 className="text-lg font-medium text-zinc-100">
+        <h2 className="text-lg font-medium text-fg">
           {isEditing ? 'Server Settings' : 'Add Server'}
         </h2>
 
         <div>
-          <label className="block text-xs text-zinc-400 mb-1">Name</label>
+          <label className="block text-xs text-fg-muted mb-1">Name</label>
           <input
             type="text"
             required
             value={form.name}
             onChange={(e) => setForm({ ...form, name: e.target.value })}
-            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+            className="w-full bg-surface-raised border border-edge rounded px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
             placeholder="My Server"
           />
         </div>
 
         <div>
-          <label className="block text-xs text-zinc-400 mb-1">Category</label>
+          <label className="block text-xs text-fg-muted mb-1">Category</label>
           <CategoryPicker
             value={form.category}
             categories={categories}
@@ -128,48 +128,48 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
         </div>
 
         <div>
-          <label className="block text-xs text-zinc-400 mb-2">Color</label>
+          <label className="block text-xs text-fg-muted mb-2">Color</label>
           <ServerColorPicker value={form.color} onChange={(color) => setForm({ ...form, color })} />
         </div>
 
         <div className="grid grid-cols-3 gap-2">
           <div className="col-span-2">
-            <label className="block text-xs text-zinc-400 mb-1">Host</label>
+            <label className="block text-xs text-fg-muted mb-1">Host</label>
             <input
               type="text"
               required
               value={form.host}
               onChange={(e) => setForm({ ...form, host: e.target.value })}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+              className="w-full bg-surface-raised border border-edge rounded px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
               placeholder="192.168.1.1"
             />
           </div>
           <div>
-            <label className="block text-xs text-zinc-400 mb-1">Port</label>
+            <label className="block text-xs text-fg-muted mb-1">Port</label>
             <input
               type="number"
               value={form.port}
               onChange={(e) => setForm({ ...form, port: parseInt(e.target.value) || 22 })}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+              className="w-full bg-surface-raised border border-edge rounded px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
             />
           </div>
         </div>
 
         <div>
-          <label className="block text-xs text-zinc-400 mb-1">Username</label>
+          <label className="block text-xs text-fg-muted mb-1">Username</label>
           <input
             type="text"
             required
             value={form.username}
             onChange={(e) => setForm({ ...form, username: e.target.value })}
-            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+            className="w-full bg-surface-raised border border-edge rounded px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
           />
         </div>
 
         <div>
-          <label className="block text-xs text-zinc-400 mb-1">Auth Method</label>
+          <label className="block text-xs text-fg-muted mb-1">Auth Method</label>
           <div className="flex gap-4">
-            <label className="flex items-center gap-1.5 text-sm text-zinc-300">
+            <label className="flex items-center gap-1.5 text-sm text-fg-tertiary">
               <input
                 type="radio"
                 name="auth"
@@ -178,7 +178,7 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
               />
               SSH Key
             </label>
-            <label className="flex items-center gap-1.5 text-sm text-zinc-300">
+            <label className="flex items-center gap-1.5 text-sm text-fg-tertiary">
               <input
                 type="radio"
                 name="auth"
@@ -192,12 +192,12 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
 
         {form.authMethod === 'key' && (
           <div>
-            <label className="block text-xs text-zinc-400 mb-1">Private Key Path</label>
+            <label className="block text-xs text-fg-muted mb-1">Private Key Path</label>
             <input
               type="text"
               value={form.privateKeyPath}
               onChange={(e) => setForm({ ...form, privateKeyPath: e.target.value })}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+              className="w-full bg-surface-raised border border-edge rounded px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
               placeholder="~/.ssh/id_rsa"
             />
           </div>
@@ -205,7 +205,7 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
 
         {form.authMethod === 'password' && (
           <div>
-            <label className="block text-xs text-zinc-400 mb-1">
+            <label className="block text-xs text-fg-muted mb-1">
               {isEditing ? 'New Password' : 'Password'}
             </label>
             <input
@@ -218,10 +218,10 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
                   setClearSavedPassword(false)
                 }
               }}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+              className="w-full bg-surface-raised border border-edge rounded px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
               placeholder={isEditing ? 'Leave blank to keep current password' : 'Enter password'}
             />
-            <p className="text-xs text-zinc-600 mt-1">
+            <p className="text-xs text-fg-dim mt-1">
               {isEditing && server?.hasPassword
                 ? 'Leave blank to keep the current saved password.'
                 : 'Encrypted and stored locally via OS keychain. Paulus only reads it when you connect.'}
@@ -232,16 +232,16 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
                   type="checkbox"
                   checked={clearSavedPassword}
                   onChange={(e) => setClearSavedPassword(e.target.checked)}
-                  className="rounded border-zinc-600 bg-zinc-800"
+                  className="rounded border-edge-strong bg-surface-raised"
                 />
-                <span className="text-sm text-zinc-300">Remove saved password</span>
+                <span className="text-sm text-fg-tertiary">Remove saved password</span>
               </label>
             )}
           </div>
         )}
 
         {isEditing && form.authMethod === 'key' && server?.hasPassword && (
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-fg-faint">
             Switching to SSH key authentication removes the saved password.
           </p>
         )}
@@ -252,22 +252,22 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
             checked={autoConnectAvailable && form.autoConnect}
             onChange={(e) => setForm({ ...form, autoConnect: e.target.checked })}
             disabled={!autoConnectAvailable}
-            className="rounded border-zinc-600 bg-zinc-800"
+            className="rounded border-edge-strong bg-surface-raised"
           />
-          <span className={`text-sm ${autoConnectAvailable ? 'text-zinc-300' : 'text-zinc-500'}`}>
+          <span className={`text-sm ${autoConnectAvailable ? 'text-fg-tertiary' : 'text-fg-faint'}`}>
             Auto-connect on launch
           </span>
         </label>
 
         {!autoConnectAvailable && (
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-fg-faint">
             Launch auto-connect is only available for SSH key authentication. Password-based servers
             require manual connect so the OS keychain prompt never appears on app open.
           </p>
         )}
 
         {isEditing && (
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-fg-faint">
             If this server is already connected, reconnect to apply updated connection details.
           </p>
         )}
@@ -288,14 +288,14 @@ export function ServerForm({ server, onClose, onDelete }: ServerFormProps) {
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200"
+            className="px-4 py-2 text-sm text-fg-muted hover:text-fg-secondary"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 text-sm bg-zinc-100 text-zinc-900 rounded hover:bg-zinc-200 disabled:opacity-50"
+            className="px-4 py-2 text-sm bg-surface-invert text-fg-invert rounded hover:bg-surface-invert-hover disabled:opacity-50"
           >
             {saving
               ? isEditing

--- a/packages/ui/src/components/servers/server-list.tsx
+++ b/packages/ui/src/components/servers/server-list.tsx
@@ -135,7 +135,7 @@ export function ServerList({
   )
 
   if (visibleCategoryGroups.length === 0) {
-    return <p className="text-xs text-zinc-600 px-2 py-4 text-center">No servers yet</p>
+    return <p className="text-xs text-fg-dim px-2 py-4 text-center">No servers yet</p>
   }
 
   return (
@@ -151,7 +151,7 @@ export function ServerList({
             key={group.name}
             className={`rounded-lg border px-1 py-1 ${
               isCategoryDropTarget
-                ? 'border-zinc-600 bg-zinc-900'
+                ? 'border-edge-strong bg-surface-alt'
                 : 'border-transparent bg-transparent'
             }`}
             onDragOver={(event) => {
@@ -239,7 +239,7 @@ export function ServerList({
                           openContextMenu(server.id, event.clientX, event.clientY)
                         }}
                         className={`cursor-pointer select-none rounded px-2 py-2 ${
-                          isActive ? 'bg-zinc-800' : 'hover:bg-zinc-800/50'
+                          isActive ? 'bg-surface-raised' : 'hover:bg-surface-raised/50'
                         } ${draggedServerId === server.id ? 'opacity-50' : ''}`}
                         style={
                           server.color
@@ -258,14 +258,14 @@ export function ServerList({
                                   ? 'bg-yellow-400'
                                   : connection?.status === 'error'
                                     ? 'bg-red-400'
-                                    : 'bg-zinc-600'
+                                    : 'bg-surface-strong'
                             }`}
                           />
                           <div className="min-w-0 flex-1">
-                            <p className="truncate text-sm leading-5 text-zinc-200">
+                            <p className="truncate text-sm leading-5 text-fg-secondary">
                               {server.name}
                             </p>
-                            <p className="truncate text-xs text-zinc-500">
+                            <p className="truncate text-xs text-fg-faint">
                               {anonymousMode ? maskHost(server.host) : server.host}
                             </p>
                           </div>
@@ -278,7 +278,7 @@ export function ServerList({
                               const rect = event.currentTarget.getBoundingClientRect()
                               openContextMenu(server.id, rect.right - 8, rect.bottom + 4)
                             }}
-                            className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200"
+                            className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded text-fg-faint hover:bg-surface-raised hover:text-fg-secondary"
                           >
                             <svg
                               className="h-4 w-4"
@@ -360,14 +360,14 @@ function buildCategoryGroups(
 }
 
 function DropIndicator() {
-  return <div className="mx-2 my-1 h-1 rounded-full bg-zinc-100/90" />
+  return <div className="mx-2 my-1 h-1 rounded-full bg-surface-invert/90" />
 }
 
 function EmptyCategorySlot({ highlighted }: { highlighted: boolean }) {
   return (
     <div
       className={`mx-2 my-1 rounded border border-dashed px-2 py-3 text-center text-[11px] ${
-        highlighted ? 'border-zinc-500 text-zinc-300' : 'border-zinc-800 text-zinc-600'
+        highlighted ? 'border-edge-strong text-fg-tertiary' : 'border-edge-subtle text-fg-dim'
       }`}
     >
       Drop servers here
@@ -436,7 +436,7 @@ function CategoryHeader({
               onCancelRename()
             }
           }}
-          className="w-full rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-200 focus:border-zinc-500 focus:outline-none"
+          className="w-full rounded border border-edge bg-surface-alt px-2 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-fg-secondary focus:border-edge-strong focus:outline-none"
         />
       </div>
     )
@@ -450,7 +450,7 @@ function CategoryHeader({
         onDoubleClick={() => {
           if (!isDefaultCategory) onStartRename()
         }}
-        className="flex min-w-0 flex-1 items-center gap-1 truncate text-left text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500 hover:text-zinc-300"
+        className="flex min-w-0 flex-1 items-center gap-1 truncate text-left text-[11px] font-medium uppercase tracking-[0.18em] text-fg-faint hover:text-fg-tertiary"
         title={
           isDefaultCategory
             ? `${name} — click to ${isCollapsed ? 'expand' : 'collapse'}`
@@ -459,7 +459,7 @@ function CategoryHeader({
         aria-expanded={!isCollapsed}
       >
         <svg
-          className={`h-3 w-3 flex-shrink-0 text-zinc-500 transition-transform ${
+          className={`h-3 w-3 flex-shrink-0 text-fg-faint transition-transform ${
             isCollapsed ? '-rotate-90' : ''
           }`}
           viewBox="0 0 20 20"
@@ -475,7 +475,7 @@ function CategoryHeader({
         <span className="truncate">{name}</span>
       </button>
       <div className="flex items-center gap-1">
-        <span className="rounded-full bg-zinc-900 px-1.5 py-0.5 text-[10px] text-zinc-500">
+        <span className="rounded-full bg-surface-alt px-1.5 py-0.5 text-[10px] text-fg-faint">
           {count}
         </span>
         {!isDefaultCategory && (
@@ -485,7 +485,7 @@ function CategoryHeader({
               onClick={onStartRename}
               title="Rename category"
               aria-label={`Rename ${name}`}
-              className="flex h-5 w-5 items-center justify-center rounded text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200"
+              className="flex h-5 w-5 items-center justify-center rounded text-fg-faint hover:bg-surface-raised hover:text-fg-secondary"
             >
               <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
                 <path d="M13.586 3.586a2 2 0 1 1 2.828 2.828l-.793.793-2.828-2.828.793-.793ZM11.379 5.793 3 14.172V17h2.828l8.379-8.379-2.828-2.828Z" />
@@ -508,7 +508,7 @@ function CategoryHeader({
               }}
               title="Delete category"
               aria-label={`Delete ${name}`}
-              className="flex h-5 w-5 items-center justify-center rounded text-zinc-500 hover:bg-zinc-800 hover:text-red-300"
+              className="flex h-5 w-5 items-center justify-center rounded text-fg-faint hover:bg-surface-raised hover:text-red-300"
             >
               <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
                 <path
@@ -552,7 +552,7 @@ function ServerContextMenu({
 }) {
   return (
     <div
-      className="fixed z-50 min-w-48 overflow-hidden rounded-md border border-zinc-700 bg-zinc-900 py-1 shadow-2xl"
+      className="fixed z-50 min-w-48 overflow-hidden rounded-md border border-edge bg-surface-alt py-1 shadow-2xl"
       style={{ left: x, top: y }}
       onClick={(event) => event.stopPropagation()}
     >
@@ -584,8 +584,8 @@ function ServerContextMenu({
 
       {categories.length > 0 && (
         <>
-          <div className="my-1 border-t border-zinc-800" />
-          <div className="px-3 pb-0.5 pt-1 text-[10px] uppercase tracking-wider text-zinc-500">
+          <div className="my-1 border-t border-edge-subtle" />
+          <div className="px-3 pb-0.5 pt-1 text-[10px] uppercase tracking-wider text-fg-faint">
             Move to
           </div>
           <div className="max-h-48 overflow-y-auto">
@@ -602,12 +602,12 @@ function ServerContextMenu({
                       onMoveToCategory(category)
                     }
                   }}
-                  className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800 disabled:cursor-default disabled:text-zinc-500 disabled:hover:bg-transparent"
+                  className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm text-fg-secondary hover:bg-surface-raised disabled:cursor-default disabled:text-fg-faint disabled:hover:bg-transparent"
                 >
                   <span className="truncate">{category}</span>
                   {isCurrent && (
                     <svg
-                      className="h-3.5 w-3.5 text-zinc-500"
+                      className="h-3.5 w-3.5 text-fg-faint"
                       viewBox="0 0 20 20"
                       fill="currentColor"
                     >
@@ -642,7 +642,7 @@ function ContextMenuButton({
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className="flex w-full items-center px-3 py-2 text-left text-sm text-zinc-200 hover:bg-zinc-800 disabled:cursor-default disabled:text-zinc-500 disabled:hover:bg-transparent"
+      className="flex w-full items-center px-3 py-2 text-left text-sm text-fg-secondary hover:bg-surface-raised disabled:cursor-default disabled:text-fg-faint disabled:hover:bg-transparent"
     >
       {label}
     </button>

--- a/packages/ui/src/components/servers/server-settings-view.tsx
+++ b/packages/ui/src/components/servers/server-settings-view.tsx
@@ -101,11 +101,11 @@ export function ServerSettingsView({ server }: ServerSettingsViewProps) {
   }
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-zinc-950">
-      <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
+    <div className="flex-1 flex flex-col min-h-0 bg-surface">
+      <div className="px-6 py-4 border-b border-edge-subtle flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-zinc-100">Server Settings</h2>
-          <p className="text-xs text-zinc-500 mt-1">
+          <h2 className="text-lg font-semibold text-fg">Server Settings</h2>
+          <p className="text-xs text-fg-faint mt-1">
             {anonymousMode ? maskUsername(server.username) : server.username}@
             {anonymousMode ? maskHost(server.host) : server.host}:
             {anonymousMode ? maskPort(server.port) : server.port}
@@ -113,13 +113,13 @@ export function ServerSettingsView({ server }: ServerSettingsViewProps) {
         </div>
         <button
           onClick={closeSettingsView}
-          className="text-zinc-400 hover:text-zinc-100 text-sm px-3 py-1.5 rounded-md hover:bg-zinc-800 transition-colors"
+          className="text-fg-muted hover:text-fg text-sm px-3 py-1.5 rounded-md hover:bg-surface-raised transition-colors"
         >
           Close
         </button>
       </div>
 
-      <div className="border-b border-zinc-800 px-6">
+      <div className="border-b border-edge-subtle px-6">
         <div className="flex gap-2 overflow-x-auto py-3">
           {TABS.map((tab) => (
             <button
@@ -127,8 +127,8 @@ export function ServerSettingsView({ server }: ServerSettingsViewProps) {
               onClick={() => setActiveTab(tab.id)}
               className={`px-3 py-1.5 text-sm rounded-md whitespace-nowrap transition-colors ${
                 activeTab === tab.id
-                  ? 'bg-zinc-100 text-zinc-900'
-                  : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'
+                  ? 'bg-surface-invert text-fg-invert'
+                  : 'text-fg-muted hover:text-fg hover:bg-surface-raised'
               }`}
             >
               {tab.label}
@@ -185,18 +185,18 @@ export function ServerSettingsView({ server }: ServerSettingsViewProps) {
           )}
         </div>
 
-        <div className="border-t border-zinc-800 px-6 py-4 bg-zinc-950 flex items-center justify-end gap-2">
+        <div className="border-t border-edge-subtle px-6 py-4 bg-surface flex items-center justify-end gap-2">
           <button
             type="button"
             onClick={closeSettingsView}
-            className="px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200"
+            className="px-4 py-2 text-sm text-fg-muted hover:text-fg-secondary"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 text-sm bg-zinc-100 text-zinc-900 rounded hover:bg-zinc-200 disabled:opacity-50"
+            className="px-4 py-2 text-sm bg-surface-invert text-fg-invert rounded hover:bg-surface-invert-hover disabled:opacity-50"
           >
             {saving ? 'Saving...' : 'Save Changes'}
           </button>
@@ -234,23 +234,23 @@ function GeneralTab({
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">General</h3>
-        <p className="text-sm text-zinc-500 mt-1">Basic server identity and connection target.</p>
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">General</h3>
+        <p className="text-sm text-fg-faint mt-1">Basic server identity and connection target.</p>
       </div>
 
       <div>
-        <label className="block text-xs text-zinc-500 mb-1.5">Name</label>
+        <label className="block text-xs text-fg-faint mb-1.5">Name</label>
         <input
           type="text"
           required
           value={form.name}
           onChange={(e) => onChange({ name: e.target.value })}
-          className="w-full max-w-md px-3 py-2 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:border-blue-500"
+          className="w-full max-w-md px-3 py-2 bg-surface-alt border border-edge rounded-md text-sm text-fg focus:outline-none focus:border-blue-500"
         />
       </div>
 
       <div className="max-w-md">
-        <label className="block text-xs text-zinc-500 mb-1.5">Category</label>
+        <label className="block text-xs text-fg-faint mb-1.5">Category</label>
         <CategoryPicker
           value={form.category}
           categories={categories}
@@ -259,40 +259,40 @@ function GeneralTab({
       </div>
 
       <div>
-        <label className="block text-xs text-zinc-500 mb-2">Color</label>
+        <label className="block text-xs text-fg-faint mb-2">Color</label>
         <ServerColorPicker value={form.color} onChange={(color) => onChange({ color })} />
       </div>
 
       <div className="grid grid-cols-3 gap-3 max-w-md">
         <div className="col-span-2">
-          <label className="block text-xs text-zinc-500 mb-1.5">Host</label>
+          <label className="block text-xs text-fg-faint mb-1.5">Host</label>
           <input
             type="text"
             required
             value={form.host}
             onChange={(e) => onChange({ host: e.target.value })}
-            className="w-full px-3 py-2 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:border-blue-500"
+            className="w-full px-3 py-2 bg-surface-alt border border-edge rounded-md text-sm text-fg focus:outline-none focus:border-blue-500"
           />
         </div>
         <div>
-          <label className="block text-xs text-zinc-500 mb-1.5">Port</label>
+          <label className="block text-xs text-fg-faint mb-1.5">Port</label>
           <input
             type="number"
             value={form.port}
             onChange={(e) => onChange({ port: parseInt(e.target.value) || 22 })}
-            className="w-full px-3 py-2 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:border-blue-500"
+            className="w-full px-3 py-2 bg-surface-alt border border-edge rounded-md text-sm text-fg focus:outline-none focus:border-blue-500"
           />
         </div>
       </div>
 
       <div>
-        <label className="block text-xs text-zinc-500 mb-1.5">Username</label>
+        <label className="block text-xs text-fg-faint mb-1.5">Username</label>
         <input
           type="text"
           required
           value={form.username}
           onChange={(e) => onChange({ username: e.target.value })}
-          className="w-full max-w-md px-3 py-2 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:border-blue-500"
+          className="w-full max-w-md px-3 py-2 bg-surface-alt border border-edge rounded-md text-sm text-fg focus:outline-none focus:border-blue-500"
         />
       </div>
     </section>
@@ -323,16 +323,16 @@ function AuthenticationTab({
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">
           Authentication Settings
         </h3>
-        <p className="text-sm text-zinc-500 mt-1">
+        <p className="text-sm text-fg-faint mt-1">
           Choose how Paulus authenticates when connecting to this server.
         </p>
       </div>
 
       <div className="flex gap-4">
-        <label className="flex items-center gap-1.5 text-sm text-zinc-300">
+        <label className="flex items-center gap-1.5 text-sm text-fg-tertiary">
           <input
             type="radio"
             name="auth"
@@ -341,7 +341,7 @@ function AuthenticationTab({
           />
           SSH Key
         </label>
-        <label className="flex items-center gap-1.5 text-sm text-zinc-300">
+        <label className="flex items-center gap-1.5 text-sm text-fg-tertiary">
           <input
             type="radio"
             name="auth"
@@ -355,18 +355,18 @@ function AuthenticationTab({
       {authMethod === 'key' && (
         <>
           <div>
-            <label className="block text-xs text-zinc-500 mb-1.5">Private Key Path</label>
+            <label className="block text-xs text-fg-faint mb-1.5">Private Key Path</label>
             <input
               type="text"
               value={privateKeyPath}
               onChange={(e) => onPrivateKeyPathChange(e.target.value)}
-              className="w-full max-w-md px-3 py-2 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:border-blue-500"
+              className="w-full max-w-md px-3 py-2 bg-surface-alt border border-edge rounded-md text-sm text-fg focus:outline-none focus:border-blue-500"
               placeholder="~/.ssh/id_rsa"
             />
           </div>
 
           {hasSavedPassword && (
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-fg-faint">
               Switching to SSH key authentication removes the saved password.
             </p>
           )}
@@ -375,15 +375,15 @@ function AuthenticationTab({
 
       {authMethod === 'password' && (
         <div className="max-w-md">
-          <label className="block text-xs text-zinc-500 mb-1.5">New Password</label>
+          <label className="block text-xs text-fg-faint mb-1.5">New Password</label>
           <input
             type="password"
             value={password}
             onChange={(e) => onPasswordChange(e.target.value)}
-            className="w-full px-3 py-2 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:border-blue-500"
+            className="w-full px-3 py-2 bg-surface-alt border border-edge rounded-md text-sm text-fg focus:outline-none focus:border-blue-500"
             placeholder="Leave blank to keep current password"
           />
-          <p className="text-xs text-zinc-500 mt-1.5">
+          <p className="text-xs text-fg-faint mt-1.5">
             {hasSavedPassword
               ? 'Leave blank to keep the current saved password.'
               : 'Encrypted and stored locally via OS keychain. Paulus only reads it when you connect.'}
@@ -394,9 +394,9 @@ function AuthenticationTab({
                 type="checkbox"
                 checked={clearSavedPassword}
                 onChange={(e) => onClearSavedPasswordChange(e.target.checked)}
-                className="rounded border-zinc-600 bg-zinc-800"
+                className="rounded border-edge-strong bg-surface-raised"
               />
-              <span className="text-sm text-zinc-300">Remove saved password</span>
+              <span className="text-sm text-fg-tertiary">Remove saved password</span>
             </label>
           )}
         </div>
@@ -419,8 +419,8 @@ function AdvancedTab({
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">Advanced</h3>
-        <p className="text-sm text-zinc-500 mt-1">
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">Advanced</h3>
+        <p className="text-sm text-fg-faint mt-1">
           Runtime behavior and connection convenience settings.
         </p>
       </div>
@@ -431,19 +431,19 @@ function AdvancedTab({
           checked={autoConnectAvailable && autoConnect}
           onChange={(e) => onAutoConnectChange(e.target.checked)}
           disabled={!autoConnectAvailable}
-          className="rounded border-zinc-600 bg-zinc-800"
+          className="rounded border-edge-strong bg-surface-raised"
         />
-        <span className={`text-sm ${autoConnectAvailable ? 'text-zinc-300' : 'text-zinc-500'}`}>
+        <span className={`text-sm ${autoConnectAvailable ? 'text-fg-tertiary' : 'text-fg-faint'}`}>
           Auto-connect on launch
         </span>
       </label>
 
       {autoConnectAvailable ? (
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-fg-faint">
           If this server is already connected, reconnect to apply updated connection details.
         </p>
       ) : (
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-fg-faint">
           Launch auto-connect is only available for SSH key authentication. Password-based servers
           require manual connect so the OS keychain prompt never appears on app open.
         </p>
@@ -465,15 +465,15 @@ function DangerTab({
     <section className="space-y-5">
       <div>
         <h3 className="text-sm font-medium text-red-300 uppercase tracking-wide">Danger Zone</h3>
-        <p className="text-sm text-zinc-500 mt-1">
+        <p className="text-sm text-fg-faint mt-1">
           Remove this server, its saved password, and all related sessions.
         </p>
       </div>
 
       <div className="max-w-2xl rounded-lg border border-red-500/30 bg-red-500/5 p-4 flex items-center justify-between gap-4">
         <div>
-          <div className="text-sm text-zinc-100">Remove server</div>
-          <div className="text-xs text-zinc-500 mt-1">
+          <div className="text-sm text-fg">Remove server</div>
+          <div className="text-xs text-fg-faint mt-1">
             This cannot be undone. Session history for this server will be deleted.
           </div>
         </div>

--- a/packages/ui/src/components/sessions/new-session-dialog.tsx
+++ b/packages/ui/src/components/sessions/new-session-dialog.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import type { ServerConfig, ServerConnection } from '@paulus/shared'
+
+interface NewSessionDialogProps {
+  servers: ServerConfig[]
+  connections: Record<string, ServerConnection>
+  activeServerId: string | null
+  onSubmit: (serverIds: string[]) => void
+  onCancel: () => void
+}
+
+export function NewSessionDialog({
+  servers,
+  connections,
+  activeServerId,
+  onSubmit,
+  onCancel,
+}: NewSessionDialogProps) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => {
+    const initial = new Set<string>()
+    if (activeServerId) initial.add(activeServerId)
+    return initial
+  })
+
+  const toggle = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (selectedIds.size === 0) return
+    // Put the active server first so it remains the "primary"
+    const ids = [...selectedIds].sort((a, b) => {
+      if (a === activeServerId) return -1
+      if (b === activeServerId) return 1
+      return 0
+    })
+    onSubmit(ids)
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-surface-alt border border-edge rounded-lg p-6 w-96 space-y-4"
+      >
+        <h2 className="text-lg font-medium text-fg">New Chat Session</h2>
+        <p className="text-sm text-fg-muted">
+          Select which servers the AI should have access to in this session.
+        </p>
+
+        <div className="max-h-64 overflow-y-auto space-y-1 rounded-md border border-edge-subtle bg-surface p-2">
+          {servers.length === 0 ? (
+            <p className="text-xs text-fg-faint py-3 text-center">No servers configured</p>
+          ) : (
+            servers.map((server) => {
+              const conn = connections[server.id]
+              const isConnected = conn?.status === 'connected'
+              const isSelected = selectedIds.has(server.id)
+
+              return (
+                <label
+                  key={server.id}
+                  className={`flex items-center gap-3 rounded-md px-3 py-2 cursor-pointer transition-colors ${
+                    isSelected
+                      ? 'bg-surface-raised text-fg'
+                      : 'text-fg-muted hover:bg-surface-raised/50 hover:text-fg-secondary'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggle(server.id)}
+                    className="rounded border-edge-strong bg-surface-raised text-fg focus:ring-edge-strong"
+                  />
+                  <span
+                    className={`h-2 w-2 rounded-full flex-shrink-0 ${
+                      isConnected ? 'bg-emerald-400' : 'bg-surface-strong'
+                    }`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm truncate">{server.name}</div>
+                    <div className="text-[11px] text-fg-faint truncate">
+                      {server.username}@{server.host}
+                    </div>
+                  </div>
+                </label>
+              )
+            })
+          )}
+        </div>
+
+        {selectedIds.size > 1 && (
+          <p className="text-xs text-fg-faint">
+            {selectedIds.size} servers selected — the AI will be able to run commands on all of
+            them.
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-sm text-fg-muted hover:text-fg-secondary"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={selectedIds.size === 0}
+            className="px-4 py-2 text-sm bg-surface-invert text-fg-invert rounded hover:bg-surface-invert-hover disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Create
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/packages/ui/src/components/sessions/session-list.tsx
+++ b/packages/ui/src/components/sessions/session-list.tsx
@@ -105,7 +105,9 @@ export function SessionList() {
               <div
                 key={session.id}
                 className={`group flex items-stretch gap-1 rounded-md transition-colors min-w-0 ${
-                  activeSessionId === session.id ? 'bg-surface-raised' : 'hover:bg-surface-raised/50'
+                  activeSessionId === session.id
+                    ? 'bg-surface-raised'
+                    : 'hover:bg-surface-raised/50'
                 }`}
               >
                 <button
@@ -118,9 +120,7 @@ export function SessionList() {
                 >
                   <div className="text-sm truncate">{getSessionPreview(session)}</div>
                   <div className="flex items-center gap-1.5 mt-0.5">
-                    <span className="text-xs text-fg-dim">
-                      {formatTime(session.updatedAt)}
-                    </span>
+                    <span className="text-xs text-fg-dim">{formatTime(session.updatedAt)}</span>
                     {isMultiServer && (
                       <span
                         className="text-[10px] text-fg-faint bg-surface-raised px-1.5 py-0.5 rounded"

--- a/packages/ui/src/components/sessions/session-list.tsx
+++ b/packages/ui/src/components/sessions/session-list.tsx
@@ -1,11 +1,13 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useChatStore, useServerStore } from '../../stores'
 import { useBridge } from '../../hooks/use-bridge'
+import { NewSessionDialog } from './new-session-dialog'
 
 export function SessionList() {
   const bridge = useBridge()
   const activeServerId = useServerStore((s) => s.activeServerId)
   const servers = useServerStore((s) => s.servers)
+  const connections = useServerStore((s) => s.connections)
   const {
     sessions,
     activeSessionId,
@@ -15,6 +17,7 @@ export function SessionList() {
     loadSessions,
     init,
   } = useChatStore()
+  const [showNewSessionDialog, setShowNewSessionDialog] = useState(false)
 
   const activeServer = servers.find((s) => s.id === activeServerId)
 
@@ -25,12 +28,12 @@ export function SessionList() {
   }, [activeServerId])
 
   const serverSessions = Object.values(sessions)
-    .filter((s) => s.serverId === activeServerId)
+    .filter((s) => activeServerId && s.serverIds.includes(activeServerId))
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
 
   if (!activeServerId) {
     return (
-      <div className="px-4 py-8 text-center text-zinc-500 text-xs">
+      <div className="px-4 py-8 text-center text-fg-faint text-xs">
         Select a server to view sessions
       </div>
     )
@@ -38,7 +41,17 @@ export function SessionList() {
 
   const handleNewSession = () => {
     if (!activeServerId) return
-    createSession(bridge, activeServerId)
+    // If only one server exists, create directly without showing dialog
+    if (servers.length <= 1) {
+      createSession(bridge, [activeServerId])
+      return
+    }
+    setShowNewSessionDialog(true)
+  }
+
+  const handleCreateSession = (serverIds: string[]) => {
+    setShowNewSessionDialog(false)
+    createSession(bridge, serverIds)
   }
 
   const handleDeleteSession = (sessionId: string) => {
@@ -71,53 +84,80 @@ export function SessionList() {
   return (
     <>
       <div className="flex items-center justify-between px-2 py-1 min-w-0 gap-2">
-        <span className="text-xs font-medium text-zinc-500 uppercase truncate">
+        <span className="text-xs font-medium text-fg-faint uppercase truncate">
           {activeServer?.name ?? 'Sessions'}
         </span>
         <button
           onClick={handleNewSession}
-          className="text-xs text-zinc-400 hover:text-zinc-100 px-2 py-0.5 rounded hover:bg-zinc-800"
+          className="text-xs text-fg-muted hover:text-fg px-2 py-0.5 rounded hover:bg-surface-raised"
         >
           + New
         </button>
       </div>
 
       {serverSessions.length === 0 ? (
-        <div className="px-4 py-6 text-center text-zinc-500 text-xs">No sessions yet</div>
+        <div className="px-4 py-6 text-center text-fg-faint text-xs">No sessions yet</div>
       ) : (
         <div className="space-y-0.5">
-          {serverSessions.map((session) => (
-            <div
-              key={session.id}
-              className={`group flex items-stretch gap-1 rounded-md transition-colors min-w-0 ${
-                activeSessionId === session.id ? 'bg-zinc-800' : 'hover:bg-zinc-800/50'
-              }`}
-            >
-              <button
-                onClick={() => setActiveSession(session.id)}
-                className={`flex-1 min-w-0 text-left px-3 py-2 rounded-md transition-colors ${
-                  activeSessionId === session.id
-                    ? 'text-zinc-100'
-                    : 'text-zinc-400 hover:text-zinc-200'
+          {serverSessions.map((session) => {
+            const isMultiServer = session.serverIds.length > 1
+            return (
+              <div
+                key={session.id}
+                className={`group flex items-stretch gap-1 rounded-md transition-colors min-w-0 ${
+                  activeSessionId === session.id ? 'bg-surface-raised' : 'hover:bg-surface-raised/50'
                 }`}
               >
-                <div className="text-sm truncate">{getSessionPreview(session)}</div>
-                <div className="text-xs text-zinc-600 mt-0.5">{formatTime(session.updatedAt)}</div>
-              </button>
-              <button
-                onClick={() => handleDeleteSession(session.id)}
-                className={`px-2 text-xs text-zinc-500 hover:text-red-300 transition-colors ${
-                  activeSessionId === session.id
-                    ? 'opacity-100'
-                    : 'opacity-0 group-hover:opacity-100'
-                }`}
-                title="Delete session"
-              >
-                Delete
-              </button>
-            </div>
-          ))}
+                <button
+                  onClick={() => setActiveSession(session.id)}
+                  className={`flex-1 min-w-0 text-left px-3 py-2 rounded-md transition-colors ${
+                    activeSessionId === session.id
+                      ? 'text-fg'
+                      : 'text-fg-muted hover:text-fg-secondary'
+                  }`}
+                >
+                  <div className="text-sm truncate">{getSessionPreview(session)}</div>
+                  <div className="flex items-center gap-1.5 mt-0.5">
+                    <span className="text-xs text-fg-dim">
+                      {formatTime(session.updatedAt)}
+                    </span>
+                    {isMultiServer && (
+                      <span
+                        className="text-[10px] text-fg-faint bg-surface-raised px-1.5 py-0.5 rounded"
+                        title={session.serverIds
+                          .map((id) => servers.find((s) => s.id === id)?.name ?? id)
+                          .join(', ')}
+                      >
+                        {session.serverIds.length} servers
+                      </span>
+                    )}
+                  </div>
+                </button>
+                <button
+                  onClick={() => handleDeleteSession(session.id)}
+                  className={`px-2 text-xs text-fg-faint hover:text-red-300 transition-colors ${
+                    activeSessionId === session.id
+                      ? 'opacity-100'
+                      : 'opacity-0 group-hover:opacity-100'
+                  }`}
+                  title="Delete session"
+                >
+                  Delete
+                </button>
+              </div>
+            )
+          })}
         </div>
+      )}
+
+      {showNewSessionDialog && (
+        <NewSessionDialog
+          servers={servers}
+          connections={connections}
+          activeServerId={activeServerId}
+          onSubmit={handleCreateSession}
+          onCancel={() => setShowNewSessionDialog(false)}
+        />
       )}
     </>
   )

--- a/packages/ui/src/components/settings/settings-view.tsx
+++ b/packages/ui/src/components/settings/settings-view.tsx
@@ -369,7 +369,9 @@ function AIProviderTab({
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">AI Provider</h3>
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">
+          AI Provider
+        </h3>
         <p className="text-sm text-fg-faint mt-1">
           Choose the default backend for new chat sessions. Active chats can override provider and
           model directly in the composer.
@@ -621,7 +623,9 @@ function DataStorageTab({
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">Data Storage</h3>
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">
+          Data Storage
+        </h3>
         <p className="text-sm text-fg-faint mt-1">
           Make storage behavior explicit and export everything when needed.
         </p>

--- a/packages/ui/src/components/settings/settings-view.tsx
+++ b/packages/ui/src/components/settings/settings-view.tsx
@@ -246,21 +246,21 @@ export function SettingsView({ onClose }: SettingsViewProps) {
   }
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-zinc-950">
-      <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
+    <div className="flex-1 flex flex-col min-h-0 bg-surface">
+      <div className="px-6 py-4 border-b border-edge-subtle flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-zinc-100">Settings</h2>
-          <p className="text-xs text-zinc-500 mt-1">Global behavior, appearance, and storage.</p>
+          <h2 className="text-lg font-semibold text-fg">Settings</h2>
+          <p className="text-xs text-fg-faint mt-1">Global behavior, appearance, and storage.</p>
         </div>
         <button
           onClick={onClose}
-          className="text-zinc-400 hover:text-zinc-100 text-sm px-3 py-1.5 rounded-md hover:bg-zinc-800 transition-colors"
+          className="text-fg-muted hover:text-fg text-sm px-3 py-1.5 rounded-md hover:bg-surface-raised transition-colors"
         >
           Close
         </button>
       </div>
 
-      <div className="border-b border-zinc-800 px-6">
+      <div className="border-b border-edge-subtle px-6">
         <div className="flex gap-2 overflow-x-auto py-3">
           {TABS.map((tab) => (
             <button
@@ -268,8 +268,8 @@ export function SettingsView({ onClose }: SettingsViewProps) {
               onClick={() => setActiveTab(tab.id)}
               className={`px-3 py-1.5 text-sm rounded-md whitespace-nowrap transition-colors ${
                 activeTab === tab.id
-                  ? 'bg-zinc-100 text-zinc-900'
-                  : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'
+                  ? 'bg-surface-invert text-fg-invert'
+                  : 'text-fg-muted hover:text-fg hover:bg-surface-raised'
               }`}
             >
               {tab.label}
@@ -327,12 +327,12 @@ export function SettingsView({ onClose }: SettingsViewProps) {
         {activeTab === 'updates' && <UpdatesTab />}
       </div>
 
-      <div className="border-t border-zinc-800 px-6 py-4 bg-zinc-950 flex items-center justify-between gap-3">
-        <p className="text-xs text-zinc-500">Changes save immediately.</p>
+      <div className="border-t border-edge-subtle px-6 py-4 bg-surface flex items-center justify-between gap-3">
+        <p className="text-xs text-fg-faint">Changes save immediately.</p>
         <button
           type="button"
           onClick={onClose}
-          className="px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200"
+          className="px-4 py-2 text-sm text-fg-muted hover:text-fg-secondary"
         >
           Close
         </button>
@@ -369,8 +369,8 @@ function AIProviderTab({
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">AI Provider</h3>
-        <p className="text-sm text-zinc-500 mt-1">
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">AI Provider</h3>
+        <p className="text-sm text-fg-faint mt-1">
           Choose the default backend for new chat sessions. Active chats can override provider and
           model directly in the composer.
         </p>
@@ -390,7 +390,7 @@ function AIProviderTab({
               className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
                 isActive
                   ? 'border-blue-500/50 bg-blue-500/10'
-                  : 'border-zinc-800 bg-zinc-900 hover:border-zinc-700 hover:bg-zinc-800/50'
+                  : 'border-edge-subtle bg-surface-alt hover:border-edge hover:bg-surface-raised/50'
               }`}
             >
               <div className="flex items-start gap-3">
@@ -401,12 +401,12 @@ function AIProviderTab({
                 >
                   <div
                     className={`w-3 h-3 rounded-full border-2 flex-shrink-0 ${
-                      isActive ? 'border-blue-400 bg-blue-400' : 'border-zinc-600'
+                      isActive ? 'border-blue-400 bg-blue-400' : 'border-edge-strong'
                     }`}
                   />
                   <div className="min-w-0">
-                    <div className="text-sm font-medium text-zinc-100">{info.label}</div>
-                    <div className="text-xs text-zinc-500 mt-0.5">{info.description}</div>
+                    <div className="text-sm font-medium text-fg">{info.label}</div>
+                    <div className="text-xs text-fg-faint mt-0.5">{info.description}</div>
                   </div>
                 </button>
 
@@ -420,7 +420,7 @@ function AIProviderTab({
                       onTest(type).catch(() => {})
                     }}
                     disabled={busyAction !== null}
-                    className="rounded-md border border-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:border-zinc-500 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="rounded-md border border-edge px-3 py-1.5 text-xs text-fg-secondary hover:border-edge-strong disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {isTesting ? 'Testing...' : 'Test'}
                   </button>
@@ -436,11 +436,11 @@ function AIProviderTab({
                   }`}
                 >
                   <div className="font-medium">{testResult.detail}</div>
-                  <div className="mt-1 text-zinc-300">
+                  <div className="mt-1 text-fg-tertiary">
                     Tool: {testResult.toolName} · called: {testResult.toolCalled ? 'yes' : 'no'}
                   </div>
                   {testResult.responseText && (
-                    <div className="mt-2 rounded-md border border-zinc-800 bg-zinc-950/80 px-3 py-2 text-zinc-300 whitespace-pre-wrap break-words">
+                    <div className="mt-2 rounded-md border border-edge-subtle bg-surface/80 px-3 py-2 text-fg-tertiary whitespace-pre-wrap break-words">
                       {testResult.responseText}
                     </div>
                   )}
@@ -448,7 +448,7 @@ function AIProviderTab({
               )}
 
               {!testResult && isTesting && (
-                <div className="mt-3 text-xs text-zinc-500">
+                <div className="mt-3 text-xs text-fg-faint">
                   Waiting for the provider to call the Paulus self-test tool and return a short
                   response.
                 </div>
@@ -475,8 +475,8 @@ function AppearanceTab({
   return (
     <section className="space-y-6">
       <div>
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">Appearance</h3>
-        <p className="text-sm text-zinc-500 mt-1">Control the app theme.</p>
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">Appearance</h3>
+        <p className="text-sm text-fg-faint mt-1">Control the app theme.</p>
       </div>
 
       <div className="flex gap-2">
@@ -487,7 +487,7 @@ function AppearanceTab({
             className={`px-4 py-2 rounded-lg text-sm capitalize transition-colors ${
               theme === option
                 ? 'bg-blue-500/20 text-blue-400 border border-blue-500/50'
-                : 'bg-zinc-900 text-zinc-400 border border-zinc-800 hover:border-zinc-700'
+                : 'bg-surface-alt text-fg-muted border border-edge-subtle hover:border-edge'
             }`}
           >
             {option}
@@ -495,9 +495,9 @@ function AppearanceTab({
         ))}
       </div>
 
-      <div className="pt-2 border-t border-zinc-800">
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">Privacy</h3>
-        <p className="text-sm text-zinc-500 mt-1">
+      <div className="pt-2 border-t border-edge-subtle">
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">Privacy</h3>
+        <p className="text-sm text-fg-faint mt-1">
           Useful for screen sharing, demos, or recordings.
         </p>
 
@@ -506,11 +506,11 @@ function AppearanceTab({
             type="checkbox"
             checked={anonymousMode}
             onChange={(e) => onAnonymousModeChange(e.target.checked)}
-            className="mt-0.5 rounded border-zinc-600 bg-zinc-800"
+            className="mt-0.5 rounded border-edge-strong bg-surface-raised"
           />
           <div>
-            <div className="text-sm text-zinc-200">Anonymous mode</div>
-            <div className="text-xs text-zinc-500 mt-0.5">
+            <div className="text-sm text-fg-secondary">Anonymous mode</div>
+            <div className="text-xs text-fg-faint mt-0.5">
               Hide sensitive connection details — host, IP, username, and port — by masking them
               with asterisks (e.g. <span className="font-mono">***.***.***.***</span>). Your server
               configuration is unchanged; only the display is masked.
@@ -536,29 +536,29 @@ function TerminalTab({
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">Terminal</h3>
-        <p className="text-sm text-zinc-500 mt-1">Tune the embedded terminal rendering.</p>
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">Terminal</h3>
+        <p className="text-sm text-fg-faint mt-1">Tune the embedded terminal rendering.</p>
       </div>
 
       <div>
-        <label className="block text-xs text-zinc-500 mb-1.5">Font Size</label>
+        <label className="block text-xs text-fg-faint mb-1.5">Font Size</label>
         <input
           type="number"
           min={10}
           max={24}
           value={fontSize}
           onChange={(e) => onFontSizeChange(parseInt(e.target.value) || 14)}
-          className="w-24 px-3 py-2 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:border-blue-500"
+          className="w-24 px-3 py-2 bg-surface-alt border border-edge rounded-md text-sm text-fg focus:outline-none focus:border-blue-500"
         />
       </div>
 
       <div>
-        <label className="block text-xs text-zinc-500 mb-1.5">Font Family</label>
+        <label className="block text-xs text-fg-faint mb-1.5">Font Family</label>
         <input
           type="text"
           value={fontFamily}
           onChange={(e) => onFontFamilyChange(e.target.value)}
-          className="w-full max-w-md px-3 py-2 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:border-blue-500"
+          className="w-full max-w-md px-3 py-2 bg-surface-alt border border-edge rounded-md text-sm text-fg focus:outline-none focus:border-blue-500"
         />
       </div>
     </section>
@@ -621,21 +621,21 @@ function DataStorageTab({
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">Data Storage</h3>
-        <p className="text-sm text-zinc-500 mt-1">
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">Data Storage</h3>
+        <p className="text-sm text-fg-faint mt-1">
           Make storage behavior explicit and export everything when needed.
         </p>
       </div>
 
-      {!overview && !error && <div className="text-sm text-zinc-500">Loading storage details…</div>}
+      {!overview && !error && <div className="text-sm text-fg-faint">Loading storage details…</div>}
 
       {overview && (
         <div className="space-y-4">
-          <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4 space-y-2">
-            <div className="text-sm text-zinc-100">
+          <div className="rounded-xl border border-edge-subtle bg-surface-alt/60 p-4 space-y-2">
+            <div className="text-sm text-fg">
               Paulus data directory: <span className="font-medium">{overview.dataDirectory}</span>
             </div>
-            <div className="text-xs text-zinc-500">
+            <div className="text-xs text-fg-faint">
               {overview.serverCount} servers, {overview.savedPasswordCount} saved passwords,{' '}
               {overview.sessionCount} stored sessions.
             </div>
@@ -645,11 +645,11 @@ function DataStorageTab({
             {storageLocations.map((location) => (
               <div
                 key={location.label}
-                className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4"
+                className="rounded-xl border border-edge-subtle bg-surface-alt/60 p-4"
               >
-                <div className="text-sm font-medium text-zinc-100">{location.label}</div>
-                <div className="mt-1 text-xs text-zinc-500">{location.description}</div>
-                <div className="mt-3 rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-xs text-zinc-300 break-all">
+                <div className="text-sm font-medium text-fg">{location.label}</div>
+                <div className="mt-1 text-xs text-fg-faint">{location.description}</div>
+                <div className="mt-3 rounded-md border border-edge-subtle bg-surface px-3 py-2 text-xs text-fg-tertiary break-all">
                   {location.path}
                 </div>
               </div>
@@ -662,7 +662,7 @@ function DataStorageTab({
                 onOpenDirectory().catch(() => {})
               }}
               disabled={busyAction !== null}
-              className="px-4 py-2 rounded-lg text-sm bg-zinc-900 text-zinc-200 border border-zinc-800 hover:border-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-4 py-2 rounded-lg text-sm bg-surface-alt text-fg-secondary border border-edge-subtle hover:border-edge disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {busyAction === 'open-directory' ? 'Opening...' : 'Open data directory'}
             </button>
@@ -671,7 +671,7 @@ function DataStorageTab({
                 onExportServers().catch(() => {})
               }}
               disabled={busyAction !== null}
-              className="px-4 py-2 rounded-lg text-sm bg-zinc-900 text-zinc-200 border border-zinc-800 hover:border-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-4 py-2 rounded-lg text-sm bg-surface-alt text-fg-secondary border border-edge-subtle hover:border-edge disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {busyAction === 'export-servers' ? 'Exporting...' : 'Export servers and passwords'}
             </button>
@@ -687,12 +687,12 @@ function DataStorageTab({
           </div>
 
           {importResult && (
-            <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4 space-y-3">
+            <div className="rounded-xl border border-edge-subtle bg-surface-alt/60 p-4 space-y-3">
               <div>
-                <div className="text-sm font-medium text-zinc-100">Last Royal TSX import</div>
-                <div className="mt-1 text-xs text-zinc-500 break-all">{importResult.filePath}</div>
+                <div className="text-sm font-medium text-fg">Last Royal TSX import</div>
+                <div className="mt-1 text-xs text-fg-faint break-all">{importResult.filePath}</div>
               </div>
-              <div className="grid gap-2 text-xs text-zinc-300 sm:grid-cols-2">
+              <div className="grid gap-2 text-xs text-fg-tertiary sm:grid-cols-2">
                 <div>Imported servers: {importResult.importedServerCount}</div>
                 <div>Saved passwords: {importResult.savedPasswordCount}</div>
                 <div>Encrypted secrets read: {importResult.encryptedSecretCount}</div>
@@ -700,16 +700,16 @@ function DataStorageTab({
               </div>
               {importResult.skippedServers.length > 0 && (
                 <div className="space-y-2">
-                  <div className="text-xs font-medium text-zinc-400 uppercase tracking-wide">
+                  <div className="text-xs font-medium text-fg-muted uppercase tracking-wide">
                     Skipped entries
                   </div>
                   {importResult.skippedServers.map((entry) => (
                     <div
                       key={`${entry.name}:${entry.reason}`}
-                      className="rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2"
+                      className="rounded-md border border-edge-subtle bg-surface px-3 py-2"
                     >
-                      <div className="text-sm text-zinc-100">{entry.name}</div>
-                      <div className="mt-1 text-xs text-zinc-500">{entry.reason}</div>
+                      <div className="text-sm text-fg">{entry.name}</div>
+                      <div className="mt-1 text-xs text-fg-faint">{entry.reason}</div>
                     </div>
                   ))}
                 </div>
@@ -718,7 +718,7 @@ function DataStorageTab({
           )}
 
           <div className="space-y-2">
-            <div className="text-xs text-zinc-500">
+            <div className="text-xs text-fg-faint">
               Password storage is explicit. Switching modes rewrites `credentials.json`, and
               OS-backed encryption is not compatible with the CLI saved-password flow.
             </div>
@@ -737,18 +737,18 @@ function DataStorageTab({
                     className={`w-full text-left px-4 py-3 rounded-lg border transition-colors disabled:opacity-60 disabled:cursor-not-allowed ${
                       isActive
                         ? 'border-emerald-500/40 bg-emerald-500/10'
-                        : 'border-zinc-800 bg-zinc-900 hover:border-zinc-700 hover:bg-zinc-800/50'
+                        : 'border-edge-subtle bg-surface-alt hover:border-edge hover:bg-surface-raised/50'
                     }`}
                   >
                     <div className="flex items-center gap-3">
                       <div
                         className={`w-3 h-3 rounded-full border-2 flex-shrink-0 ${
-                          isActive ? 'border-emerald-400 bg-emerald-400' : 'border-zinc-600'
+                          isActive ? 'border-emerald-400 bg-emerald-400' : 'border-edge-strong'
                         }`}
                       />
                       <div className="min-w-0">
-                        <div className="text-sm font-medium text-zinc-100">{option.label}</div>
-                        <div className="text-xs text-zinc-500 mt-0.5">{option.description}</div>
+                        <div className="text-sm font-medium text-fg">{option.label}</div>
+                        <div className="text-xs text-fg-faint mt-0.5">{option.description}</div>
                         {!option.available && option.unavailableReason && (
                           <div className="text-xs text-amber-400 mt-1">
                             {option.unavailableReason}
@@ -757,7 +757,7 @@ function DataStorageTab({
                       </div>
                       <span
                         className={`ml-auto text-xs font-medium flex-shrink-0 ${
-                          isActive ? 'text-emerald-400' : 'text-zinc-500'
+                          isActive ? 'text-emerald-400' : 'text-fg-faint'
                         }`}
                       >
                         {isBusy ? 'Switching...' : isActive ? 'Current' : 'Use'}
@@ -824,27 +824,27 @@ function UpdatesTab() {
   return (
     <section className="space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-zinc-300 uppercase tracking-wide">Updates</h3>
-        <p className="text-sm text-zinc-500 mt-1">
+        <h3 className="text-sm font-medium text-fg-tertiary uppercase tracking-wide">Updates</h3>
+        <p className="text-sm text-fg-faint mt-1">
           Paulus Orchestrator checks for updates on startup. You can also check manually.
         </p>
       </div>
 
-      <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4 space-y-3">
+      <div className="rounded-xl border border-edge-subtle bg-surface-alt/60 p-4 space-y-3">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
-            <div className="text-xs uppercase tracking-wide text-zinc-500">Current version</div>
-            <div className="mt-1 text-sm font-medium text-zinc-100">v{currentVersion}</div>
+            <div className="text-xs uppercase tracking-wide text-fg-faint">Current version</div>
+            <div className="mt-1 text-sm font-medium text-fg">v{currentVersion}</div>
           </div>
           <div className="min-w-0 text-right">
-            <div className="text-xs uppercase tracking-wide text-zinc-500">Status</div>
+            <div className="text-xs uppercase tracking-wide text-fg-faint">Status</div>
             <div
               className={`mt-1 text-sm font-medium ${
                 status === 'error'
                   ? 'text-red-400'
                   : status === 'available' || status === 'downloaded'
                     ? 'text-blue-300'
-                    : 'text-zinc-200'
+                    : 'text-fg-secondary'
               }`}
             >
               {formatStatusLabel(status)}
@@ -867,7 +867,7 @@ function UpdatesTab() {
               </div>
             )}
             {info.releaseNotes && (
-              <pre className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-sans text-zinc-200">
+              <pre className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-sans text-fg-secondary">
                 {info.releaseNotes}
               </pre>
             )}
@@ -876,13 +876,13 @@ function UpdatesTab() {
 
         {status === 'downloading' && progress && (
           <div className="space-y-1">
-            <div className="h-2 overflow-hidden rounded-full bg-zinc-800">
+            <div className="h-2 overflow-hidden rounded-full bg-surface-raised">
               <div
                 className="h-full bg-blue-500 transition-[width]"
                 style={{ width: `${Math.max(0, Math.min(100, progress.percent))}%` }}
               />
             </div>
-            <div className="flex items-center justify-between text-xs text-zinc-500">
+            <div className="flex items-center justify-between text-xs text-fg-faint">
               <span>
                 {formatBytes(progress.transferred)} / {formatBytes(progress.total)}
               </span>
@@ -904,7 +904,7 @@ function UpdatesTab() {
               check().catch(() => {})
             }}
             disabled={!supported || isBusy}
-            className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-200 hover:border-zinc-500 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md border border-edge bg-surface-alt px-3 py-1.5 text-xs text-fg-secondary hover:border-edge-strong disabled:cursor-not-allowed disabled:opacity-50"
           >
             {status === 'checking' ? 'Checking…' : 'Check for updates'}
           </button>
@@ -958,23 +958,23 @@ export function RoyalTsxImportDialog({
         onSubmit={(event) => {
           onSubmit(event).catch(() => {})
         }}
-        className="w-[28rem] space-y-4 rounded-lg border border-zinc-700 bg-zinc-900 p-6"
+        className="w-[28rem] space-y-4 rounded-lg border border-edge bg-surface-alt p-6"
       >
         <div>
-          <h2 className="text-lg font-medium text-zinc-100">Import Royal TSX</h2>
-          <p className="mt-1 text-sm text-zinc-500">
+          <h2 className="text-lg font-medium text-fg">Import Royal TSX</h2>
+          <p className="mt-1 text-sm text-fg-faint">
             Choose your `.rtsz` file next. Enter the document password only if the Royal document is
             password-protected.
           </p>
         </div>
 
         <div>
-          <label className="mb-1.5 block text-xs text-zinc-400">Royal TSX Document Password</label>
+          <label className="mb-1.5 block text-xs text-fg-muted">Royal TSX Document Password</label>
           <input
             type="password"
             value={documentPassword}
             onChange={(event) => onPasswordChange(event.target.value)}
-            className="w-full rounded border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-zinc-500"
+            className="w-full rounded border border-edge bg-surface-raised px-3 py-2 text-sm text-fg focus:outline-none focus:border-edge-strong"
             placeholder="Leave blank if the document has no password"
             autoFocus
           />
@@ -985,14 +985,14 @@ export function RoyalTsxImportDialog({
             type="button"
             onClick={onCancel}
             disabled={busyAction === 'import-royal-tsx'}
-            className="px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-50"
+            className="px-4 py-2 text-sm text-fg-muted hover:text-fg-secondary disabled:cursor-not-allowed disabled:opacity-50"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={busyAction === 'import-royal-tsx'}
-            className="rounded bg-zinc-100 px-4 py-2 text-sm text-zinc-900 hover:bg-zinc-200 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded bg-surface-invert px-4 py-2 text-sm text-fg-invert hover:bg-surface-invert-hover disabled:cursor-not-allowed disabled:opacity-50"
           >
             {busyAction === 'import-royal-tsx' ? 'Importing...' : 'Choose File'}
           </button>

--- a/packages/ui/src/components/terminal/terminal-console.tsx
+++ b/packages/ui/src/components/terminal/terminal-console.tsx
@@ -21,7 +21,7 @@ export function TerminalConsole({ serverId, isConnected }: TerminalConsoleProps)
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const activeSession = activeSessionId ? sessions[activeSessionId] : null
-  const sessionId = activeSession?.serverId === serverId ? activeSession.id : null
+  const sessionId = activeSession?.serverIds.includes(serverId) ? activeSession.id : null
 
   useEffect(() => {
     let cancelled = false
@@ -119,7 +119,7 @@ export function TerminalConsole({ serverId, isConnected }: TerminalConsoleProps)
 
       let ensuredSessionId = sessionId
       if (!ensuredSessionId) {
-        ensuredSessionId = (await createSession(bridge, serverId)).id
+        ensuredSessionId = (await createSession(bridge, [serverId])).id
       }
 
       setHistory((prev) => [...prev, cmd])
@@ -180,13 +180,13 @@ export function TerminalConsole({ serverId, isConnected }: TerminalConsoleProps)
   }, [bridge, sessionId])
 
   return (
-    <div className="flex flex-col h-full bg-zinc-950 font-mono text-[13px]">
+    <div className="flex flex-col h-full bg-surface font-mono text-[13px]">
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-zinc-800 bg-zinc-900/50">
-        <span className="text-xs text-zinc-400 font-sans font-medium">Terminal</span>
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-edge-subtle bg-surface-alt/50">
+        <span className="text-xs text-fg-muted font-sans font-medium">Terminal</span>
         <button
           onClick={handleClear}
-          className="text-xs text-zinc-500 hover:text-zinc-300 font-sans px-1.5 py-0.5 rounded hover:bg-zinc-800"
+          className="text-xs text-fg-faint hover:text-fg-tertiary font-sans px-1.5 py-0.5 rounded hover:bg-surface-raised"
         >
           Clear
         </button>
@@ -198,7 +198,7 @@ export function TerminalConsole({ serverId, isConnected }: TerminalConsoleProps)
         onClick={() => inputRef.current?.focus()}
       >
         {lines.length === 0 && (
-          <p className="text-zinc-600 text-xs">Type a command below to execute on the server...</p>
+          <p className="text-fg-dim text-xs">Type a command below to execute on the server...</p>
         )}
         {lines.map((line) => (
           <div
@@ -210,7 +210,7 @@ export function TerminalConsole({ serverId, isConnected }: TerminalConsoleProps)
                   ? 'text-emerald-400'
                   : line.type === 'system'
                     ? 'text-yellow-400'
-                    : 'text-zinc-300'
+                    : 'text-fg-tertiary'
             }`}
           >
             {line.text}
@@ -223,7 +223,7 @@ export function TerminalConsole({ serverId, isConnected }: TerminalConsoleProps)
       {isConnected && (
         <form
           onSubmit={handleSubmit}
-          className="flex items-center gap-2 px-3 py-2 border-t border-zinc-800 bg-zinc-900/30"
+          className="flex items-center gap-2 px-3 py-2 border-t border-edge-subtle bg-surface-alt/30"
         >
           <span className="text-emerald-400 select-none">$</span>
           <input
@@ -233,7 +233,7 @@ export function TerminalConsole({ serverId, isConnected }: TerminalConsoleProps)
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             disabled={running}
-            className="flex-1 bg-transparent text-zinc-100 outline-none placeholder-zinc-600 disabled:opacity-50"
+            className="flex-1 bg-transparent text-fg outline-none placeholder-fg-dim disabled:opacity-50"
             placeholder={running ? 'Running...' : 'Enter command...'}
             autoComplete="off"
             spellCheck={false}

--- a/packages/ui/src/hooks/use-assistant-runtime.ts
+++ b/packages/ui/src/hooks/use-assistant-runtime.ts
@@ -111,7 +111,16 @@ export function useAssistantRuntime(serverIds: string[]) {
       }
       await sendMessage(bridge, serverIds, text)
     },
-    [activeSessionId, bridge, createSession, sendMessage, interruptWithMessage, isStreaming, queueMessage, serverIds],
+    [
+      activeSessionId,
+      bridge,
+      createSession,
+      sendMessage,
+      interruptWithMessage,
+      isStreaming,
+      queueMessage,
+      serverIds,
+    ],
   )
 
   return useExternalStoreRuntime({

--- a/packages/ui/src/hooks/use-assistant-runtime.ts
+++ b/packages/ui/src/hooks/use-assistant-runtime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useExternalStoreRuntime, type ThreadMessageLike } from '@assistant-ui/react'
 import type { AIMessage } from '@paulus/shared'
 import { useChatStore } from '../stores'
@@ -6,6 +6,13 @@ import { useBridge } from './use-bridge'
 import { buildMessageContent } from '../components/chat/message-content'
 
 export const STREAMING_MESSAGE_ID = '__streaming__'
+
+// Module-level flag read by onNew to decide queue vs interrupt behaviour.
+// Set synchronously before ComposerPrimitive.Send triggers the submit.
+let _nextSendMode: 'send' | 'queue' = 'send'
+export function setNextSendMode(mode: 'send' | 'queue') {
+  _nextSendMode = mode
+}
 
 const EMPTY_MESSAGES: AIMessage[] = []
 
@@ -21,7 +28,7 @@ function convertMessage(msg: AIMessage): ThreadMessageLike {
   }
 }
 
-export function useAssistantRuntime(serverId: string) {
+export function useAssistantRuntime(serverIds: string[]) {
   const bridge = useBridge()
   const {
     activeSessionId,
@@ -29,8 +36,12 @@ export function useAssistantRuntime(serverId: string) {
     streamingText,
     streamingEvents,
     isStreaming,
+    messageQueue,
     createSession,
     sendMessage,
+    interruptWithMessage,
+    queueMessage,
+    dequeueMessage,
   } = useChatStore()
 
   const session = activeSessionId ? sessions[activeSessionId] : null
@@ -68,6 +79,15 @@ export function useAssistantRuntime(serverId: string) {
     [messages, streamingMessage],
   )
 
+  // Process queued messages when streaming ends
+  useEffect(() => {
+    if (!isStreaming && messageQueue.length > 0) {
+      const next = messageQueue[0]
+      dequeueMessage()
+      sendMessage(bridge, serverIds, next)
+    }
+  }, [isStreaming, messageQueue, bridge, serverIds, sendMessage, dequeueMessage])
+
   const onNew = useCallback(
     async (message: { content: readonly { type: string; text?: string }[] }) => {
       const text = message.content
@@ -75,12 +95,23 @@ export function useAssistantRuntime(serverId: string) {
         .map((part) => part.text)
         .join('\n')
 
-      if (!activeSessionId) {
-        await createSession(bridge, serverId)
+      if (isStreaming) {
+        const mode = _nextSendMode
+        _nextSendMode = 'send' // reset
+        if (mode === 'queue') {
+          queueMessage(text)
+        } else {
+          await interruptWithMessage(bridge, serverIds, text)
+        }
+        return
       }
-      await sendMessage(bridge, serverId, text)
+
+      if (!activeSessionId) {
+        await createSession(bridge, serverIds)
+      }
+      await sendMessage(bridge, serverIds, text)
     },
-    [activeSessionId, bridge, createSession, sendMessage, serverId],
+    [activeSessionId, bridge, createSession, sendMessage, interruptWithMessage, isStreaming, queueMessage, serverIds],
   )
 
   return useExternalStoreRuntime({

--- a/packages/ui/src/stores/chat-store.ts
+++ b/packages/ui/src/stores/chat-store.ts
@@ -22,10 +22,11 @@ interface ChatStore {
   modelOptions: ProviderStateMap<AIModelOption[]>
   modelLoadState: ProviderStateMap<'idle' | 'loading' | 'loaded' | 'error'>
   modelLoadErrors: ProviderStateMap<string>
+  messageQueue: string[]
 
   init(bridge: Bridge): void
   loadSessions(bridge: Bridge, serverId: string): Promise<void>
-  createSession(bridge: Bridge, serverId: string, config?: AISessionConfig): Promise<AISession>
+  createSession(bridge: Bridge, serverIds: string[], config?: AISessionConfig): Promise<AISession>
   updateSessionConfig(bridge: Bridge, sessionId: string, config: AISessionConfig): Promise<void>
   deleteSession(bridge: Bridge, sessionId: string): Promise<void>
   removeSessionsForServer(serverId: string): void
@@ -33,10 +34,58 @@ interface ChatStore {
   ensureDraftConfig(bridge: Bridge, serverId: string): Promise<void>
   setDraftConfig(serverId: string, config: AISessionConfig): void
   loadModels(bridge: Bridge, provider: AIProviderType): Promise<void>
-  sendMessage(bridge: Bridge, serverId: string, message: string): Promise<void>
+  sendMessage(bridge: Bridge, serverIds: string[], message: string): Promise<void>
+  interruptWithMessage(bridge: Bridge, serverIds: string[], message: string): Promise<void>
+  killSession(bridge: Bridge): Promise<void>
   approveCommand(bridge: Bridge, commandId: string): Promise<void>
   rejectCommand(bridge: Bridge, commandId: string): Promise<void>
+  queueMessage(message: string): void
+  dequeueMessage(): void
   handleAIEvent(event: AIEvent & { sessionId: string }): void
+}
+
+// ─── Streaming event buffer ─────────────────────────────────────────────────
+// Coalesces rapid streaming events into frame-paced state updates so React
+// re-renders at most once per animation frame instead of once per token.
+let _streamBuf: { textDelta: string; events: AIEvent[] } = { textDelta: '', events: [] }
+let _streamRafId = 0
+
+function _flushStreamBuffer(): void {
+  _streamRafId = 0
+  const { textDelta, events } = _streamBuf
+  _streamBuf = { textDelta: '', events: [] }
+  if (!textDelta && events.length === 0) return
+  useChatStore.setState((state) => ({
+    streamingText: state.streamingText + textDelta,
+    streamingEvents: [...state.streamingEvents, ...events],
+  }))
+}
+
+function _bufferStreamEvent(event: AIEvent): void {
+  if (event.type === 'text') {
+    _streamBuf.textDelta += event.text
+  }
+  _streamBuf.events.push(event)
+  if (!_streamRafId) {
+    _streamRafId = requestAnimationFrame(_flushStreamBuffer)
+  }
+}
+
+/** Flush pending events synchronously (used before finalizing a stream). */
+function _forceFlush(): void {
+  if (_streamRafId) {
+    cancelAnimationFrame(_streamRafId)
+    _flushStreamBuffer()
+  }
+}
+
+/** Discard pending events without applying them (used when streaming is aborted). */
+function _cancelPendingFlush(): void {
+  if (_streamRafId) {
+    cancelAnimationFrame(_streamRafId)
+    _streamRafId = 0
+  }
+  _streamBuf = { textDelta: '', events: [] }
 }
 
 async function getDefaultSessionConfig(bridge: Bridge): Promise<AISessionConfig> {
@@ -59,6 +108,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   modelOptions: {},
   modelLoadState: {},
   modelLoadErrors: {},
+  messageQueue: [],
 
   init(bridge) {
     if (get().initialized) return
@@ -78,14 +128,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     const map: Record<string, AISession> = { ...get().sessions }
     // Merge: replace sessions for this server, keep others
     for (const key of Object.keys(map)) {
-      if (map[key].serverId === serverId) delete map[key]
+      if (map[key].serverIds.includes(serverId)) delete map[key]
     }
     for (const s of sessions) {
       map[s.id] = s
     }
     // Auto-select the most recent session for this server, or null
     const current = get().activeSessionId
-    const currentBelongsToServer = current && map[current]?.serverId === serverId
+    const currentBelongsToServer = current && map[current]?.serverIds.includes(serverId)
     const latest = sessions.sort(
       (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
     )[0]
@@ -98,13 +148,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     })
   },
 
-  async createSession(bridge, serverId, config) {
+  async createSession(bridge, serverIds, config) {
+    const primaryServerId = serverIds[0]
     const effectiveConfig =
-      config ?? get().draftConfigs[serverId] ?? (await getDefaultSessionConfig(bridge))
-    const session = await bridge.sessions.create(serverId, effectiveConfig)
+      config ?? get().draftConfigs[primaryServerId] ?? (await getDefaultSessionConfig(bridge))
+    const session = await bridge.sessions.create(serverIds, effectiveConfig)
     set((state) => ({
       sessions: { ...state.sessions, [session.id]: session },
-      draftConfigs: { ...state.draftConfigs, [serverId]: effectiveConfig },
+      draftConfigs: { ...state.draftConfigs, [primaryServerId]: effectiveConfig },
       activeSessionId: session.id,
     }))
     return session
@@ -114,13 +165,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     const updated = await bridge.sessions.update(sessionId, config)
     set((state) => ({
       sessions: { ...state.sessions, [sessionId]: updated },
-      draftConfigs: { ...state.draftConfigs, [updated.serverId]: config },
+      draftConfigs: { ...state.draftConfigs, [updated.serverIds[0]]: config },
     }))
   },
 
   async deleteSession(bridge, sessionId) {
     const session = get().sessions[sessionId]
     if (!session) return
+    if (get().activeSessionId === sessionId) _cancelPendingFlush()
 
     await bridge.sessions.delete(sessionId)
 
@@ -132,8 +184,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         return { sessions }
       }
 
+      const primaryServerId = session.serverIds[0]
       const nextActiveSession = Object.values(sessions)
-        .filter((candidate) => candidate.serverId === session.serverId)
+        .filter((candidate) => primaryServerId && candidate.serverIds.includes(primaryServerId))
         .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0]
 
       return {
@@ -149,13 +202,15 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   removeSessionsForServer(serverId) {
     set((state) => {
       const sessions = Object.fromEntries(
-        Object.entries(state.sessions).filter(([, session]) => session.serverId !== serverId),
+        Object.entries(state.sessions).filter(
+          ([, session]) => !session.serverIds.includes(serverId),
+        ),
       )
       const draftConfigs = { ...state.draftConfigs }
       delete draftConfigs[serverId]
       const activeSession =
         state.activeSessionId !== null ? state.sessions[state.activeSessionId] : null
-      const removedActiveSession = activeSession?.serverId === serverId
+      const removedActiveSession = activeSession?.serverIds.includes(serverId) ?? false
 
       return {
         sessions,
@@ -169,6 +224,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 
   setActiveSession(id) {
+    _cancelPendingFlush()
     set({ activeSessionId: id, streamingText: '', streamingEvents: [] })
   },
 
@@ -217,11 +273,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }
   },
 
-  async sendMessage(bridge, serverId, message) {
+  async sendMessage(bridge, serverIds, message) {
     const { activeSessionId, sessions } = get()
     if (!activeSessionId) return
     const session = sessions[activeSessionId]
-    if (!session || session.serverId !== serverId) return
+    if (!session) return
 
     // Add user message to local state
     const userMsg: AIMessage = {
@@ -247,7 +303,57 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       }
     })
 
-    await bridge.ai.send(serverId, activeSessionId, message)
+    await bridge.ai.send(serverIds, activeSessionId, message)
+  },
+
+  async interruptWithMessage(bridge, serverIds, message) {
+    const { activeSessionId } = get()
+    if (!activeSessionId) return
+
+    _forceFlush()
+
+    // Finalize partial response so it's preserved in history
+    set((state) => {
+      const session = state.sessions[activeSessionId]
+      if (!session || !state.isStreaming) {
+        return { isStreaming: false, streamingText: '', streamingEvents: [], messageQueue: [] }
+      }
+      const hasContent = state.streamingText || state.streamingEvents.length > 0
+      if (!hasContent) {
+        return { isStreaming: false, streamingText: '', streamingEvents: [], messageQueue: [] }
+      }
+      const assistantMsg: AIMessage = {
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: state.streamingText,
+        events: state.streamingEvents,
+        timestamp: new Date().toISOString(),
+      }
+      return {
+        sessions: {
+          ...state.sessions,
+          [activeSessionId]: {
+            ...session,
+            messages: [...session.messages, assistantMsg],
+          },
+        },
+        isStreaming: false,
+        streamingText: '',
+        streamingEvents: [],
+        messageQueue: [],
+      }
+    })
+
+    await bridge.ai.kill(activeSessionId)
+    await get().sendMessage(bridge, serverIds, message)
+  },
+
+  async killSession(bridge) {
+    const { activeSessionId } = get()
+    if (!activeSessionId) return
+    _cancelPendingFlush()
+    set({ isStreaming: false, streamingText: '', streamingEvents: [], messageQueue: [] })
+    await bridge.ai.kill(activeSessionId)
   },
 
   async approveCommand(bridge, commandId) {
@@ -262,17 +368,20 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     await bridge.ai.reject(activeSessionId, commandId)
   },
 
+  queueMessage(message) {
+    set((state) => ({ messageQueue: [...state.messageQueue, message] }))
+  },
+
+  dequeueMessage() {
+    set((state) => ({ messageQueue: state.messageQueue.slice(1) }))
+  },
+
   handleAIEvent(event) {
     const { activeSessionId } = get()
     if (event.sessionId !== activeSessionId) return
 
     switch (event.type) {
       case 'text':
-        set((state) => ({
-          streamingText: state.streamingText + event.text,
-          streamingEvents: [...state.streamingEvents, event],
-        }))
-        break
       case 'thinking':
       case 'tool_state':
       case 'tool_call':
@@ -282,13 +391,15 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       case 'command_output':
       case 'command_done':
       case 'error':
-        set((state) => ({
-          streamingEvents: [...state.streamingEvents, event],
-        }))
+        _bufferStreamEvent(event)
         break
       case 'done':
+        // Flush any buffered events before finalizing
+        _forceFlush()
         // Finalize streaming text as an assistant message
         set((state) => {
+          // If streaming was already cleared (e.g. by kill), skip finalization
+          if (!state.isStreaming) return state
           const session = state.sessions[activeSessionId!]
           if (!session) return { isStreaming: false, streamingText: '', streamingEvents: [] }
           const assistantMsg: AIMessage = {


### PR DESCRIPTION
## Summary
- add multi-server session and chat flow support across the bridge, Electron IPC, core orchestrator, AI context, and shared session types
- refresh the desktop chat and session UI with multi-server affordances, improved approval UX, queue/interrupt controls, debug visibility, and theme handling updates
- include the existing startup latency fix already present on this branch

## Why
- the current single-server chat flow blocks multi-host workflows and makes long-running streamed responses harder to control from the UI
- the session and settings surfaces needed to align with the new chat model and updated visual system

## Breaking Changes
- `Bridge.ai.send` now accepts `serverIds: string[]` instead of a single `serverId`
- `Bridge.sessions.create` now accepts `serverIds: string[]`
- `AIContext` now exposes `servers` instead of `server`
- `AISession` should be treated as `serverIds`-based; consumers relying on `serverId` need to migrate

## Validation
- `bun run typecheck`
- `bun run check`
